### PR TITLE
fix typo - comma, not a `

### DIFF
--- a/docs/tutorials/search-granules.md
+++ b/docs/tutorials/search-granules.md
@@ -5,7 +5,7 @@ import earthaccess
 
 results = earthaccess.search_data(
     short_name = "ATL06",
-    version = "005"'
+    version = "005",
     cloud_hosted = True, 
     bounding_box = (-10,20,10,50),
     temporal = ("2020-02", "2020-03"),


### PR DESCRIPTION
Hi @betolink et al, I believe this was a typo in the How To documentation!