### PR TITLE
Update example in `search_datasets`

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -44,7 +44,7 @@ def search_datasets(
     Examples:
         ```python
         datasets = earthaccess.search_datasets(
-            keywords="sea surface anomaly",
+            keyword="sea surface anomaly",
             cloud_hosted=True
         )
         ```


### PR DESCRIPTION
Copy and pasting this example as is gives me the following error:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[50], line 1
----> 1 datasets = earthaccess.search_datasets(
      2     keywords="sea surface anomaly",
      3     cloud_hosted=True
      4 )

File ~/mambaforge/envs/earthaccess/lib/python3.9/site-packages/earthaccess/api.py:57, in search_datasets(count, **kwargs)
     53     print(
     54         "Warning: a valid set of parameters is needed to search for datasets on CMR"
     55     )
     56     return []
---> 57 query = DataCollections().parameters(**kwargs)
     58 datasets_found = query.hits()
     59 print(f"Datasets found: {datasets_found}")

File ~/mambaforge/envs/earthaccess/lib/python3.9/site-packages/earthaccess/search.py:129, in DataCollections.parameters(self, **kwargs)
    126 for key, val in kwargs.items():
    127     # verify the key matches one of our methods
    128     if key not in methods:
--> 129         raise ValueError("Unknown key {}".format(key))
    131     # call the method
    132     if isinstance(val, tuple):

ValueError: Unknown key keywords
```

My guess is this should be `keyword` instead of `keywords` (which works locally for me)