### PR TITLE
Raise informative error without inputs to `get_s3fs_session`

### DIFF
--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -126,6 +126,11 @@ class Store(object):
             a s3fs file instance
         """
         if self.auth is not None:
+            if not any([concept_id, daac, provider]):
+                raise ValueError(
+                    "At least one of the concept_id, daac, or provider "
+                    "parameters must be specified."
+                )
             if concept_id is not None:
                 provider = self._derive_concept_provider(concept_id)
                 s3_credentials = self.auth.get_s3_credentials(provider=provider)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -3,6 +3,7 @@ import os
 import unittest
 
 import fsspec
+import pytest
 import responses
 from earthaccess import Auth, Store
 
@@ -89,4 +90,9 @@ class TestStoreSessions(unittest.TestCase):
         ]:
             s3_fs = store.get_s3fs_session(provider=provider)
             assert isinstance(s3_fs, fsspec.AbstractFileSystem)
+
+        # Ensure informative error is raised
+        with pytest.raises(ValueError, match="parameters must be specified"):
+            store.get_s3fs_session()
+
         return None


### PR DESCRIPTION
Closes https://github.com/nsidc/earthaccess/issues/248

cc @betolink