### PR TITLE
Improved remote cluster performance

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict, List, Optional, Type, Union
 
+import earthaccess
 import requests
 import s3fs
 from fsspec import AbstractFileSystem
-
-import earthaccess
 
 from .auth import Auth
 from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -568,12 +568,12 @@ class Store(object):
         return results
 
     def _open_urls_https(
-        self, urls: List[str] = [], granuales=[], n_jobs: int = 8
+        self, urls: List[str] = [], granules=[], n_jobs: int = 8
     ) -> List[fsspec.AbstractFileSystem]:
         https_fs = self.get_fsspec_session()
         if https_fs is not None:
             try:
-                fileset = _open_files(urls, granuales, https_fs)
+                fileset = _open_files(urls, granules, https_fs)
             except Exception:
                 print(
                     "An exception occurred while trying to access remote files via HTTPS: "

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -21,19 +21,19 @@ from .results import DataGranule
 from .search import DataCollections
 
 
-def _open_files(files, granuales, fs):
+def _open_files(files, granules, fs):
     def multi_thread_open(data) -> Any:
-        url, granuale = data
-        return EarthAccessFile(fs.open(url), granuale)
+        url, granule = data
+        return EarthAccessFile(fs.open(url), granule)
 
-    fileset = pqdm(zip(files, granuales), multi_thread_open, n_jobs=8)
+    fileset = pqdm(zip(files, granules), multi_thread_open, n_jobs=8)
     return fileset
 
 
-def make_instance(cls, granuale, _reduce):
+def make_instance(cls, granule, _reduce):
     if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
-        return EarthAccessFile(earthaccess.open([granuale])[0], granuale)
+        return EarthAccessFile(earthaccess.open([granule])[0], granule)
     else:
         func = _reduce[0]
         args = _reduce[1]
@@ -41,9 +41,9 @@ def make_instance(cls, granuale, _reduce):
 
 
 class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
-    def __init__(self, f, granuale):
+    def __init__(self, f, granule):
         self.f = f
-        self.granuale = granuale
+        self.granule = granule
     
     def __getattr__(self, method):
         return getattr(self.f, method)
@@ -51,7 +51,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
     def __reduce__(self):
         return make_instance, (
             type(self.f),
-            self.granuale,
+            self.granule,
             self.f.__reduce__(),
         )
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -33,6 +33,8 @@ def _open_files(files, granules, fs):
 def make_instance(cls, granule, _reduce):
     if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
+        # NOTE: This uses the first data_link listed in the granule. That's not
+        #       guaranteed to be the right one. 
         return EarthAccessFile(earthaccess.open([granule])[0], granule)
     else:
         func = _reduce[0]

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -29,12 +29,14 @@ def _open_files(files, granuales, fs):
     return fileset
 
 
-def make_instance(cls, granuale, args, kwargs):
+def make_instance(cls, granuale, _reduce):
     if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
         # On AWS but not using a S3File
         return earthaccess.open([granuale])[0]
     else:
-        return cls(*args, **kwargs)
+        func = _reduce[0]
+        args = _reduce[1]
+        return func(*args)
 
 
 class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
@@ -57,8 +59,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
         return make_instance, (
             type(self),
             self.granuale,
-            self.storage_args,
-            self.storage_options,
+            self.f.__reduce__(),
         )
 
 


### PR DESCRIPTION
This PR adds an `fsspec`-compatible `EarthAccessFile` object that's a very light wrapper around the current https / S3 file objects being used. The only difference is that when a file is serialized (as happens when working on a remote cluster), if we find that we are running in region on AWS and the underlying file is an https file instead of an S3 file, we reopen the file using the existing `eathaccess.open(...)` logic to get a S3 file. 

Anecdotally, I see a computation performance boost of 2x when running the notebook in https://github.com/nsidc/earthaccess/issues/253 with the changes in this PR 

Closes https://github.com/nsidc/earthaccess/issues/253