### PR TITLE
Limit documentation deployment

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,11 +46,11 @@ jobs:
         run: poetry run bash scripts/build-docs.sh
 
       - name: Deploy
+        if: |
+          github.event_name != 'push'
+          && github.ref == 'refs/heads/main'
+          && github.repository == 'nsidc/earthaccess'
         uses: peaceiris/actions-gh-pages@v3
         with:
-          EARTHDATA_USERNAME: ${{ secrets.EDL_USERNAME }}
-          EARTHDATA_PASSWORD: ${{ secrets.EDL_PASSWORD }}
-          EARTHACCESS_TEST_USERNAME: ${{ secrets.EDL_USERNAME }}
-          EARTHACCESS_TEST_PASSWORD: ${{ secrets.EDL_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,12 +11,14 @@ on:
       - tests/**
       - docs/**
       - notebooks/**
+      - .github/workflows/documentation.yml
   pull_request:
     paths:
       - earthaccess/**
       - tests/**
       - docs/**
       - notebooks/**
+      - .github/workflows/documentation.yml
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
This PR makes it so the docs are only deployed on pushes to the `main` branch of `nsidc/earthaccess`

cc @betolink 

xref https://github.com/nsidc/earthaccess/pull/260