### PR TITLE
add try block to return useful error message for failed download

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -164,7 +164,13 @@ def download(
     Returns:
         List of downloaded files
     """
-    results = earthaccess.__store__.get(granules, local_path, provider, threads)
+    try:
+        results = earthaccess.__store__.get(granules, local_path, provider, threads)
+    except AttributeError as err:
+        print(err)
+        print("You must call earthaccess.login() before you can download data")
+        return None
+    
     return results
 
 


### PR DESCRIPTION
This PR address #262.

Following the api workflow in the readme, if `earthaccess.login()` is not executed before download, download fails with an ambiguous `AttributeError`.  To fix this, I added a `try-except` block to `download` in `api.py`, so that the user is advised to run `earthdata.login()` before attempting to download and `None` is returned. 