### PR TITLE
Search improvements

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,6 +46,9 @@ jobs:
         run: poetry install
       - name: Build docs
         run: poetry run bash scripts/build-docs.sh
+        env:
+          EARTHDATA_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EARTHDATA_PASSWORD: ${{ secrets.EDL_PASSWORD }}
 
       - name: Deploy
         if: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,15 +1,14 @@
-name: Unit Tests
+name: Integration Tests
 
 on:
   push:
+    branches:
+      - main
     paths:
       - earthaccess/**
       - tests/**
-  pull_request:
-    paths:
-      - earthaccess/**
-      - tests/**
-    types: [opened, synchronize]
+      - docs/**
+      - binder/**
 
 jobs:
   test:
@@ -46,6 +45,11 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test
-        run: poetry run bash scripts/test.sh
+        env:
+          EARTHDATA_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EARTHDATA_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+          EARTHACCESS_TEST_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EARTHACCESS_TEST_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+        run: poetry run bash scripts/integration-test.sh
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+* bug fixes:
+    * granule's size() returned zero
+    * Added exception handling for fsspec sessions, thanks to @jrbourbeau
+* CI changes:
+    * integration tests are now only run when we push to main (after a merge)
+    * unit tests run for any branch and opened PR
+
 ## [v0.5.2] 2023-04-21
 * bug fixes:
     * Fixing #230 by removing Benedict as the dict handler, thanks to @psarka!

--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@
     <img src="https://img.shields.io/pypi/v/earthaccess?color=%2334D058&label=pypi%20package" alt="Package version">
 </a>
 
+<a href="https://anaconda.org/conda-forge/earthaccess" target="_blank">
+    <img src="https://img.shields.io/conda/vn/conda-forge/earthaccess.svg" alt="Conda Versions">
+</a>
+
 <a href="https://pypi.org/project/earthaccess/" target="_blank">
     <img src="https://img.shields.io/pypi/pyversions/earthaccess.svg" alt="Python Versions">
 </a>
 
 <a href='https://earthdata.readthedocs.io/en/latest/?badge=latest'>
-    <img src='https://readthedocs.org/projects/earthaccess/badge/?version=latest' alt='Documentation Status' />
+    <img src='https://readthedocs.org/projects/earthdata/badge/?version=latest' alt='Documentation Status' />
 </a>
 
 </p>

--- a/README.md
+++ b/README.md
@@ -94,12 +94,11 @@ If we are not sure or we don't know how to search for a particular dataset, we c
 ```python
 
 results = earthaccess.search_data(
-    short_name='ATL06',
-    version="005",
+    short_name='SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205',
     cloud_hosted=True,
     bounding_box=(-10, 20, 10, 50),
-    temporal=("2020-02", "2020-03"),
-    count=100
+    temporal=("1999-02", "2019-03"),
+    count=10
 )
 
 
@@ -140,7 +139,9 @@ This method works best if you are in the same Amazon Web Services (AWS) region a
 ```python
 import xarray as xr
 
-ds = xr.open_mfdataset(earthaccess.open(results))
+files = earthaccess.open(results)
+
+ds = xr.open_mfdataset(files)
 
 ```
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md

--- a/docs/tutorials/authenticate.md
+++ b/docs/tutorials/authenticate.md
@@ -1,7 +1,13 @@
 ## Authenticate with Earthdata Login
 
+earthaccess can use environment variables, `.netrc` file or interactive input from a user to login with NASA EDL.
+
+If a strategy is not especified, env vars will be used first, then netrc and finally user's input.
+
 ```py
 import earthaccess
+
+auth = earthaccess.login()
 ```
 
 If you have a .netrc file with your Earthdata Login credentials

--- a/docs/tutorials/file-access.ipynb
+++ b/docs/tutorials/file-access.ipynb
@@ -106,7 +106,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/queries.ipynb
+++ b/docs/tutorials/queries.ipynb
@@ -8,7 +8,7 @@
    },
    "source": [
     "\n",
-    "## Overview\n",
+    "# Overview\n",
     "\n",
     "\n",
     "# <img src=\"https://logos-world.net/wp-content/uploads/2020/05/NASA-Logo-1959-present.png\" width=\"100px\" align=\"middle\" /> Introducing NASA earthaccess 🌍\n",
@@ -38,14 +38,41 @@
     "\n",
     "Earthdata Login provides free and immediate access to thousands of EOSDIS data products covering all Earth science disciplines and topic areas for researchers, applied science users, application developers, and the general public.\n",
     "\n",
-    "Once we have our NASA EDL login credentials we can start accessing NASA data in a programmatic way.\n"
+    "Once we have our NASA EDL login credentials we can start accessing NASA data in a programmatic way.\n",
+    "\n",
+    "\n",
+    "## Querying CMR using earthaccess\n",
+    "\n",
+    "This short tutorial uses the `collection_query()` and `granule_query()` methods, these methods return a lower level Query Builder instance that can be used to query NASA's CMR.\n",
+    "For convenience the top level API also offers the `dataset_search(**kwargs)` and `data_search(**kwargs)` methods that map what these query builders do. \n",
+    "\n",
+    "For instance \n",
+    "\n",
+    "```python\n",
+    "query = earthaccess.granule_query().doi(\"some_doi\").temporal(\"1990-01-01\", \"2020-12-31\").cloud_hosted(True)\n",
+    "granules = query.get(10)\n",
+    "\n",
+    "```\n",
+    "\n",
+    "is equivalent to\n",
+    "\n",
+    "```python\n",
+    "granules = earthaccess.search_data(\n",
+    "    doi=\"some_doi\",\n",
+    "    temporal = (\"1990-01-01\",\"2020-12-31\"),\n",
+    "    cloud_hosted=True,\n",
+    "    limit=10\n",
+    ")\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "10f6c9ed-fe58-4e03-b29b-c6c447061f84",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import earthaccess\n",
@@ -85,12 +112,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "caab3b4b-80cc-4790-9417-1dd12503aa55",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# are we authenticated?\n",
     "\n",
-    "auth = earthaccess.login(strategy=\"netrc\")\n"
+    "auth = earthaccess.login()\n"
    ]
   },
   {
@@ -107,7 +136,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8d5bf4c9-571b-4c93-af94-e66bd51cb584",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# The first step is to create a DataCollections query \n",
@@ -139,7 +170,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8cb5154c-f131-44ad-a68f-cf0fa21ce18f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "collections[0][\"umm\"][\"ShortName\"]"
@@ -171,11 +204,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "48cdcd74-dfe3-4b83-93f4-7378a0d981df",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# We can now search for collections using a pythonic API client for CMR.\n",
-    "Query = earthaccess.collection_query().daac(\"PODAAC\")\n",
+    "Query = earthaccess.collection_query().daac(\"ASF\")\n",
     "\n",
     "print(f'Collections found: {Query.hits()}')\n",
     "collections = Query.fields(['ShortName']).get(10)\n",
@@ -187,11 +222,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "63792353-ab3e-4f0b-963d-7750e4b89113",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# What if we want cloud collections\n",
-    "Query = earthaccess.collection_query().daac(\"PODAAC\").cloud_hosted(True)\n",
+    "Query = earthaccess.collection_query().daac(\"ASF\").cloud_hosted(True)\n",
     "\n",
     "print(f'Collections found: {Query.hits()}')\n",
     "collections = Query.fields(['ShortName']).get(10)\n",
@@ -203,7 +240,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c4c5a34a-e808-4cc9-b34d-353d091a8242",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Printing the concept-id for the first 10 collections\n",
@@ -230,17 +269,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9364d737-5a79-4089-853f-76d2ad1c85a7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "from pprint import pprint\n",
     "\n",
     "# We build our query\n",
     "\n",
-    "Query = earthaccess.granule_query().short_name('ATL06').version(\"005\").bounding_box(-134.7,58.9,-133.9,59.2)\n",
+    "Query = earthaccess.granule_query().short_name('HLSL30').bounding_box(-134.7,58.9,-133.9,59.2)\n",
     "# We get 5 metadata records\n",
-    "granules = Query.get(5)\n",
-    "granules"
+    "granules = Query.get(5)"
    ]
   },
   {
@@ -257,12 +297,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66cd5f5c-a854-4a72-a831-33b8bd7ce9d2",
-   "metadata": {},
+   "id": "0b56b119-ec9b-4922-911a-f37501597451",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# printing 2 granules using display\n",
-    "[display(granule) for granule in granules]"
+    "[display(g) for g in granules]"
    ]
   },
   {
@@ -280,7 +321,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "00aa39ec-e2fb-49d1-bc54-8d8a2f0655aa",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "Query = earthaccess.granule_query().short_name(\"ATL06\").temporal(\"2020-03-01\", \"2020-03-30\").bounding_box(-134.7,58.9,-133.9,59.2).version(\"005\")\n",
@@ -292,7 +335,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8c493585-0d48-41bb-8815-6c83ad20ae80",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Now we can print some info about these granules using the built-in methods\n",
@@ -325,7 +370,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "910e4b90-f0e0-42e5-a4e2-d5444089161f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import earthaccess\n",
@@ -354,11 +401,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "434466a3-602b-4dff-a260-f7db6901514a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
-    "files = earthaccess.download(granules[0:4], \"./data/C1972955240-PODAAC/\")"
+    "files = earthaccess.download(granules[0:2], \"./data/C1972955240-PODAAC/\")"
    ]
   },
   {
@@ -381,7 +430,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "44403d51-0aa3-423c-8fff-e40d4969aa9d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -396,7 +447,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5e59ca3e-b5d5-490f-b967-01d1c7b3fdf0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Let's pretty print this\n",
@@ -407,7 +460,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b2a294f1-b1f9-4cd4-8751-dfc32feacec1",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -436,7 +491,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aecdb529-5961-4fa6-b7e0-70bbd0d85041",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -451,8 +508,23 @@
     "\n",
     "for granule in results:\n",
     "    https_links.extend(granule.data_links(access=\"on_prem\"))\n",
-    "    s3_links.extend(granule.data_links(access=\"direct\"))\n",
-    "s3_links"
+    "    s3_links.extend(granule.data_links(access=\"direct\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50e6f01e-86f0-4e29-869b-d6d437c8b130",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "fileset = earthaccess.open(results[0:3])\n",
+    "\n",
+    "# test that we can read data from the files\n",
+    "with fileset[0] as f:\n",
+    "    print(f.read(100))"
    ]
   },
   {
@@ -467,16 +539,21 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e693af6a-a80e-4ca2-a034-8da194c18aaf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
     "\n",
+    "# Note: this will be slow if we do it out of AWS\n",
+    "\n",
     "ds_L3 = xr.open_mfdataset(\n",
-    "    earthaccess.open(results[0:3]),\n",
+    "    fileset,\n",
     "    combine='nested',\n",
     "    concat_dim='time',\n",
     "    coords='minimal',\n",
+    "    engine=\"h5netcdf\"\n",
     "    )\n",
     "ds_L3"
    ]
@@ -548,7 +625,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.14"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/queries.ipynb
+++ b/docs/tutorials/queries.ipynb
@@ -8,11 +8,7 @@
    },
    "source": [
     "\n",
-    "# Overview\n",
-    "\n",
-    "\n",
-    "# <img src=\"https://logos-world.net/wp-content/uploads/2020/05/NASA-Logo-1959-present.png\" width=\"100px\" align=\"middle\" /> Introducing NASA earthaccess 🌍\n",
-    "\n",
+    "# Querying CMR using earthaccess\n",
     "\n",
     "\n",
     "#### TL;DR: [**earthaccess**](https://github.com/nsidc/earthaccess) is a Python package to search, preview and access NASA datasets (on-prem or in the cloud) with a few lines of code.\n",
@@ -68,15 +64,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "10f6c9ed-fe58-4e03-b29b-c6c447061f84",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0.5.3'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import earthaccess\n",
     "earthaccess.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "496c1e3e-5b1a-44f8-ae13-84c42ea814af",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EARTHDATA_USERNAME and EARTHDATA_PASSWORD are not set in the current environment, try setting them or use a different strategy (netrc, interactive)\n",
+      "You're now authenticated with NASA Earthdata Login\n",
+      "Using token with expiration date: 09/24/2023\n",
+      "Using .netrc file for EDL\n"
+     ]
+    }
+   ],
+   "source": [
+    "auth = earthaccess.login()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39ba3dfb-a2b3-459a-ba51-dd6446c20872",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token yarn"
    ]
   },
   {
@@ -359,6 +399,27 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7b80520-5cae-45c5-9397-f990a1ba0f26",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "granules = []\n",
+    "\n",
+    "# we just grab 1 granule from May for each year of the dataset\n",
+    "for year in range(1999, 2019):\n",
+    "    results = earthaccess.search_data(\n",
+    "        doi = \"10.5067/SLREF-CDRV3\",\n",
+    "        temporal=(f\"{year}-05\", f\"{year}-06\")\n",
+    "    )\n",
+    "    if len(results)>0:\n",
+    "        granules.append(results[0])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "4239e041-db87-40d1-b81a-12c26e9e0a47",
    "metadata": {},
@@ -379,8 +440,9 @@
     "\n",
     "earthaccess.login()\n",
     "\n",
-    "Query = earthaccess.granule_query().short_name(\"SMAP_JPL_L3_SSS_CAP_8DAY-RUNNINGMEAN_V5\").bounding_box(-134.7,54.9,-100.9,69.2)\n",
+    "Query = earthaccess.granule_query().doi(\"10.5067/SLREF-CDRV3\").bounding_box(-134.7,54.9,-100.9,69.2)\n",
     "print(f\"Granule hits: {Query.hits()}\")\n",
+    "\n",
     "# getting more than 6,000 metadata records for demo purposes is going to slow us down a bit so let's get only a few\n",
     "granules = Query.get(10)\n",
     "# Does this granule belong to a cloud-based collection?\n",
@@ -512,6 +574,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "0cb71d7d-c77e-497b-9846-ba101e730457",
+   "metadata": {},
+   "source": [
+    "### With earthaccess we can open URLS if we pass the provider or we can open the results directly and will derive the necessary credentials to use."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "50e6f01e-86f0-4e29-869b-d6d437c8b130",
@@ -525,37 +595,6 @@
     "# test that we can read data from the files\n",
     "with fileset[0] as f:\n",
     "    print(f.read(100))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0cb71d7d-c77e-497b-9846-ba101e730457",
-   "metadata": {},
-   "source": [
-    "### With earthaccess we can open URLS if we pass the provider or we can open the results directly and will derive the necessary credentials to use."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e693af6a-a80e-4ca2-a034-8da194c18aaf",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "# Note: this will be slow if we do it out of AWS\n",
-    "\n",
-    "ds_L3 = xr.open_mfdataset(\n",
-    "    fileset,\n",
-    "    combine='nested',\n",
-    "    concat_dim='time',\n",
-    "    coords='minimal',\n",
-    "    engine=\"h5netcdf\"\n",
-    "    )\n",
-    "ds_L3"
    ]
   },
   {

--- a/docs/tutorials/restricted-datasets.ipynb
+++ b/docs/tutorials/restricted-datasets.ipynb
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List, Optional, Type, Union
 
-import earthaccess
 import requests
 import s3fs
 from fsspec import AbstractFileSystem
+
+import earthaccess
 
 from .auth import Auth
 from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery
@@ -168,8 +169,7 @@ def download(
     except AttributeError as err:
         print(err)
         print("You must call earthaccess.login() before you can download data")
-        return None
-    
+        return []
     return results
 
 

--- a/earthaccess/formatters.py
+++ b/earthaccess/formatters.py
@@ -23,7 +23,7 @@ def _repr_granule_html(granule: Any) -> str:
     css_inline = f"""<div id="{uuid4()}" style="height: 0px; display: none">
             {''.join([f"<style>{style}</style>" for style in css_styles])}
             </div>"""
-    style = "max-height: 140px;"
+    style = "max-height: 120px;"
     dataviz_img = "".join(
         [
             f'<a href="{link}"><img style="{style}" src="{link}" alt="Data Preview"/></a>'
@@ -47,7 +47,7 @@ def _repr_granule_html(granule: Any) -> str:
           <div class="col-6">
             <p><b>Data</b>: {data_links}<p/>
             <p><b>Size</b>: {granule_size} MB</p>
-            <p><b>Spatial</b>: <span>{granule["umm"]["SpatialExtent"]}</span></p>
+            <p><b>Cloud Hosted</b>: <span>{granule.cloud_hosted}</span></p>
           </div>
           <div class="col-2 offset-sm-3 pull-right">
             {dataviz_img}

--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -247,7 +247,7 @@ class DataGranule(CustomDict):
             Returns the total size for the granule in MB
         """
         try:
-            data_granule = self["mmm"]["DataGranule"]
+            data_granule = self["umm"]["DataGranule"]
             total_size = sum(
                 [
                     float(s["Size"])
@@ -257,7 +257,7 @@ class DataGranule(CustomDict):
             )
         except Exception:
             try:
-                data_granule = self["mmm"]["DataGranule"]
+                data_granule = self["umm"]["DataGranule"]
                 total_size = sum(
                     [
                         float(s["SizeInBytes"])

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -681,3 +681,23 @@ class DataGranules(GranuleQuery):
         """
         super().downloadable(downloadable)
         return self
+
+    def doi(self, doi: str) -> Type[GranuleQuery]:
+        """Searh data granules by DOI
+
+        ???+ Tip
+            Not all datasets have an associated DOI, internally if a DOI is found
+            earthaccess will grab the concept_id for the query to CMR.
+
+        Parameters:
+            doi (String): DOI of a datasets, e.g. 10.5067/AQR50-3Q7CS
+        """
+        collection = CollectionQuery().doi(doi).get()
+        if len(collection) > 0:
+            concept_id = collection[0].concept_id()
+            self.params["concept_id"] = concept_id
+        else:
+            print(
+                f"earthaccess couldn't find any associated collections with the DOI: {doi}"
+            )
+        return self

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -692,7 +692,7 @@ class DataGranules(GranuleQuery):
         Parameters:
             doi (String): DOI of a datasets, e.g. 10.5067/AQR50-3Q7CS
         """
-        collection = CollectionQuery().doi(doi).get()
+        collection = DataCollections().doi(doi).get()
         if len(collection) > 0:
             concept_id = collection[0].concept_id()
             self.params["concept_id"] = concept_id

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -412,6 +412,24 @@ class DataGranules(GranuleQuery):
                 self.params["provider"] = provider
         return self
 
+    def granule_name(self, granule_name: str) -> Type[CollectionQuery]:
+        """Find granules matching either granule ur or producer granule id,
+        queries using the readable_granule_name metadata field.
+
+        ???+ Tip
+            We can use wirldcards on a granule name to further refine our search
+            i.e. MODGRNLD.*.daily.*
+
+        Parameters:
+            granule_name (String): granule name (accepts wildcards)
+        """
+        if not isinstance(granule_name, str):
+            raise TypeError("granule_name must be of type string")
+
+        self.params["readable_granule_name"] = granule_name
+        self.params["options[readable_granule_name][pattern]"] = True
+        return self
+
     def online_only(self, online_only: bool = True) -> Type[GranuleQuery]:
         """Only match granules that are listed online and not available for download.
         The opposite of this method is downloadable().

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -37,6 +37,9 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
             self.f.__reduce__(),
         )
 
+    def __repr__(self) -> str:
+        return str(self.f)
+
 
 def _open_files(
     data_links: List[str],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - OVERVIEW: 'index.md'
   - TUTORIALS:
       - 'Querying CMR using earthaccess': 'tutorials/queries.ipynb'
+      - 'Accesing files with fsspec': 'tutorials/file-access.ipynb'
       - 'Search and access restricted datasets': 'tutorials/restricted-datasets.ipynb'
   - HOW-TO:
       - 'Authenticate with Earthdata Login': 'tutorials/authenticate.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,7 +45,7 @@ plugins:
 nav:
   - OVERVIEW: 'index.md'
   - TUTORIALS:
-      - 'Introducing NASA earthaccess': 'tutorials/demo.ipynb'
+      - 'Querying CMR using earthaccess': 'tutorials/queries.ipynb'
       - 'Search and access restricted datasets': 'tutorials/restricted-datasets.ipynb'
   - HOW-TO:
       - 'Authenticate with Earthdata Login': 'tutorials/authenticate.md'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "earthaccess"
-version = "0.5.2"
+version = "0.5.3"
 homepage = "https://github.com/nsidc/earthaccess"
 description = "Client library for NASA Earthdata APIs"
 authors = ["earthaccess contributors"]

--- a/scripts/docs-live.sh
+++ b/scripts/docs-live.sh
@@ -4,4 +4,4 @@
 set -e
 set -x
 
-mkdocs serve --dev-addr 0.0.0.0:8008
+mkdocs serve --dev-addr 0.0.0.0:8008 --dirtyreload

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+pytest --cov=earthaccess --cov=tests --cov-report=term-missing ${@} -s --tb=native --log-cli-level=INFO
+bash ./scripts/lint.sh

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-pytest --cov=earthaccess --cov=tests --cov-report=term-missing ${@} -s --tb=native --log-cli-level=INFO
+pytest --cov=earthaccess --cov=tests/integration --cov-report=term-missing ${@} -s --tb=native --log-cli-level=INFO
 bash ./scripts/lint.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -3,5 +3,5 @@
 set -e
 set -x
 
-pytest --cov=earthaccess --cov=tests --cov-report=term-missing ${@} -s --tb=native --log-cli-level=INFO
+pytest tests/unit --cov=earthaccess --cov=tests --cov-report=term-missing ${@} -s --tb=native --log-cli-level=INFO
 bash ./scripts/lint.sh

--- a/tests/integration/test_onprem_download.py
+++ b/tests/integration/test_onprem_download.py
@@ -31,14 +31,6 @@ daacs_list = [
         "granules_max_size_mb": 130,
     },
     {
-        "short_name": "PODAAC",
-        "collections_count": 100,
-        "collections_sample_size": 2,
-        "granules_count": 100,
-        "granules_sample_size": 2,
-        "granules_max_size_mb": 100,
-    },
-    {
         "short_name": "LPDAAC",
         "collections_count": 100,
         "collections_sample_size": 2,

--- a/tests/integration/test_onprem_open.py
+++ b/tests/integration/test_onprem_open.py
@@ -38,14 +38,6 @@ daacs_list = [
         "granules_max_size_mb": 100,
     },
     {
-        "short_name": "LPDAAC",
-        "collections_count": 100,
-        "collections_sample_size": 2,
-        "granules_count": 100,
-        "granules_sample_size": 2,
-        "granules_max_size_mb": 100,
-    },
-    {
         "short_name": "ORNLDAAC",
         "collections_count": 100,
         "collections_sample_size": 2,


### PR DESCRIPTION
Features:
* we can search by doi at the granule level, if a collection is found `earthaccess` will grab the `concept_id` and search using it.
* users will be able to use pattern matching on the granule file names!
* README is now using the SSHA dataset from PODAAC as is simpler to explain and work with compared to ATL data, closes #241
* The granule representation removed the spatial output in favor of a simpler is_cloud_hosted until we have a nicer spatial formatter (it was a blob of json)

Bug fixes:
* size() now returns the actual size closes #233

Documentation:
* using earthdata.login() instead of a specific strategy, addresses #218 

CI:
* integration tests are only going to run on pushes to main
* documentation is only going to be updated when we update main
TODO:
* documentation needs more work and we need to fill the placeholders


Using a doi to get granules directly is not supported by CMR as not all collections have a DOI or some have multiple dois but it is a common way of identifying a dataset. If a collection is associated to a DOI earthaccess can use it to get to the data.

```python
    results = earthaccess.search_data(
        doi = "10.5067/SLREF-CDRV3",
        temporal=("2001-05", "2001-06")
    )
```

another common access pattern is to filter using regexes on the granule names, this is now supported:

```python
    results = earthaccess.search_data(
        doi = "10.5067/SLREF-CDRV3",
        temporal=("2001-01", "2002-01"),
        granule_name="*2001.01-*.nc"
    )
```