### PR TITLE
Avoid auth error when serializing files across processes

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -176,6 +176,7 @@ def download(
 def open(
     granules: Union[List[str], List[earthaccess.results.DataGranule]],
     provider: Optional[str] = None,
+    store: Optional[Store] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of fsspec file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.
@@ -186,7 +187,8 @@ def open(
     Returns:
         a list of s3fs "file pointers" to s3 files.
     """
-    results = earthaccess.__store__.open(granules=granules, provider=provider)
+    store = store or earthaccess.__store__
+    results = store.open(granules=granules, provider=provider)
     return results
 
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -176,7 +176,6 @@ def download(
 def open(
     granules: Union[List[str], List[earthaccess.results.DataGranule]],
     provider: Optional[str] = None,
-    store: Optional[Store] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of fsspec file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.
@@ -187,8 +186,7 @@ def open(
     Returns:
         a list of s3fs "file pointers" to s3 files.
     """
-    store = store or earthaccess.__store__
-    results = store.open(granules=granules, provider=provider)
+    results = earthaccess.__store__.open(granules=granules, provider=provider)
     return results
 
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -20,6 +20,7 @@ import earthaccess
 from .daac import DAAC_TEST_URLS, find_provider
 from .results import DataGranule
 from .search import DataCollections
+from .auth import Auth
 
 
 class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
@@ -33,8 +34,8 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
     def __reduce__(self) -> Any:
         return make_instance, (
             type(self.f),
-            self.f,
-            earthaccess.__store__,
+            self.granule,
+            earthaccess.__auth__,
             self.f.__reduce__(),
         )
 
@@ -63,12 +64,19 @@ def _open_files(
     return fileset
 
 
-def make_instance(cls: Any, granule: DataGranule, store, _reduce: Any) -> EarthAccessFile:
-    if store.running_in_aws and cls is not s3fs.S3File:
+def make_instance(
+    cls: Any, granule: DataGranule, auth: Auth, _reduce: Any
+) -> EarthAccessFile:
+    # Attempt to re-authenticate
+    if not earthaccess.__auth__.authenticated:
+        earthaccess.__auth__ = auth
+        earthaccess.login()
+
+    if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
         # NOTE: This uses the first data_link listed in the granule. That's not
         #       guaranteed to be the right one.
-        return EarthAccessFile(earthaccess.open([granule], store=store)[0], granule)
+        return EarthAccessFile(earthaccess.open([granule])[0], granule)
     else:
         func = _reduce[0]
         args = _reduce[1]

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -34,6 +34,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
         return make_instance, (
             type(self.f),
             self.f,
+            earthaccess.__store__,
             self.f.__reduce__(),
         )
 
@@ -62,12 +63,12 @@ def _open_files(
     return fileset
 
 
-def make_instance(cls: Any, granule: DataGranule, _reduce: Any) -> EarthAccessFile:
-    if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
+def make_instance(cls: Any, granule: DataGranule, store, _reduce: Any) -> EarthAccessFile:
+    if store.running_in_aws and cls is not s3fs.S3File:
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
         # NOTE: This uses the first data_link listed in the granule. That's not
         #       guaranteed to be the right one.
-        return EarthAccessFile(earthaccess.open([granule])[0], granule)
+        return EarthAccessFile(earthaccess.open([granule], store=store)[0], granule)
     else:
         func = _reduce[0]
         args = _reduce[1]


### PR DESCRIPTION
With https://github.com/nsidc/earthaccess/pull/259, when serializing files, we started re-checking the filesystem type (HTTPS vs. S3) and, if we are on AWS but not using S3 files, we now re-open the file using an `s3fs` filesystem.

This is good for performance, but when running on a remote Dask cluster, users now need to have all nodes in their cluster (i.e. client, scheduler, and workers) authenticated with `earthaccess`. For example, if only the client session is authenticated, like in this example:

```python
import earthaccess
from distributed import SubprocessCluster
import xarray as xr

earthaccess.login()

# Create a cluster where the scheduler / workers are in local subprocessses.
# This has the same serialization characteristics as a remote cluster.
cluster = SubprocessCluster()
client = cluster.get_client()

results = earthaccess.search_data(
    short_name="VIIRS_NPP-STAR-L3U-v2.80",
    concept_id="C2147485059-POCLOUD",
    cloud_hosted=True,
    count=1,  # For testing purposes
)

ds = xr.open_mfdataset(earthaccess.open(results))
result = ds.sea_surface_temperature.notnull().mean({"lon", "lat"}).compute()
print(result)
```

users encounter the following error


```
Traceback (most recent call last):
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/scheduler.py", line 4346, in update_graph
    graph = deserialize(graph_header, graph_frames).data
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 432, in deserialize
    return loads(header, frames)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 98, in pickle_loads
    return pickle.loads(x, buffers=buffers)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/pickle.py", line 96, in loads
    return pickle.loads(x)
  File "/Users/james/projects/nsidc/earthaccess/earthaccess/store.py", line 66, in make_instance
    if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
AttributeError: 'NoneType' object has no attribute 'running_in_aws'
```

<details>
<summary>Full traceback:</summary>

```
Traceback (most recent call last):
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/scheduler.py", line 4346, in update_graph
    graph = deserialize(graph_header, graph_frames).data
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 432, in deserialize
    return loads(header, frames)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/serialize.py", line 98, in pickle_loads
    return pickle.loads(x, buffers=buffers)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/protocol/pickle.py", line 96, in loads
    return pickle.loads(x)
  File "/Users/james/projects/nsidc/earthaccess/earthaccess/store.py", line 66, in make_instance
    if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
AttributeError: 'NoneType' object has no attribute 'running_in_aws'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/james/projects/nsidc/earthaccess/test.py", line 20, in <module>
    result = ds.sea_surface_temperature.notnull().mean({"lon", "lat"}).compute()
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/xarray/core/dataarray.py", line 1101, in compute
    return new.load(**kwargs)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/xarray/core/dataarray.py", line 1075, in load
    ds = self._to_temp_dataset().load(**kwargs)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/xarray/core/dataset.py", line 747, in load
    evaluated_data = da.compute(*lazy_data.values(), **kwargs)
  File "/Users/james/mambaforge/envs/nasa/lib/python3.9/site-packages/distributed/client.py", line 2247, in _gather
    raise exception.with_traceback(traceback)
RuntimeError: Error during deserialization of the task graph. This frequently occurs if the Scheduler and Client have different environments. For more information, see https://docs.dask.org/en/stable/deployment-considerations.html#consistent-software-environments
```

</details>

Because other nodes, in this case the scheduler, are attempting to check if they're on AWS, but aren't authed with `earthaccess`, so things error. 

While it's possible to authenticate the other nodes in the cluster with `earthaccess` with some additional client-side code, most users won't want to / know how to handle this additional authentication step. 

This PR proposes we handle this for them by forwarding the existing client-side `earthaccess` auth object alongside data files, and then re-auth (only if needed) if we need to re-open the file. 

This seems sensible to me, but is just one possible approach. I'd welcome any thoughts others may have. 

cc @betolink @MattF-NSIDC