### PR TITLE
Add metadata consolidation utility

### DIFF
--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -17,6 +17,7 @@ from .api import (
 from .auth import Auth
 from .search import DataCollections, DataGranules
 from .store import Store
+from .kerchunk import consolidate_metadata
 
 __all__ = [
     "login",

--- a/earthaccess/kerchunk.py
+++ b/earthaccess/kerchunk.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dask.base import flatten
+from dask.distributed import default_client, progress, Client, Worker, WorkerPlugin
+from kerchunk.combine import MultiZarrToZarr
+from kerchunk.hdf import SingleHdf5ToZarr
+
+import earthaccess
+from .auth import Auth
+
+
+def get_chunk_metadata(
+    granuale: earthaccess.results.DataGranule, access: str
+) -> list[dict]:
+    if access == "direct":
+        fs_data = earthaccess.get_s3fs_session(provider=granuale["meta"]["provider-id"])
+    else:
+        fs_data = earthaccess.get_fsspec_https_session()
+
+    metadata = []
+    for url in granuale.data_links(access=access):
+        with fs_data.open(url) as inf:
+            h5chunks = SingleHdf5ToZarr(inf, url)
+            m = h5chunks.translate()
+            metadata.append(m)
+    return metadata
+
+
+class EarthAccessAuth(WorkerPlugin):
+    name = "earthaccess-auth"
+
+    def __init__(self, auth: Auth):
+        self.auth = auth
+
+    def setup(self, worker: Worker) -> None:
+        if not earthaccess.__auth__.authenticated:
+            earthaccess.__auth__ = self.auth
+            earthaccess.login()
+
+
+def consolidate_metadata(
+    granuales: list[earthaccess.results.DataGranule],
+    outfile: str,
+    storage_options: dict | None = None,
+    kerchunk_options: dict | None = None,
+    access: str = "direct",
+    client: Client | None = None,
+) -> str:
+    if client is None:
+        client = default_client()
+
+    # Make sure cluster is authenticated
+    client.register_worker_plugin(EarthAccessAuth(earthaccess.__auth__))
+
+    # Write out metadata file for each granuale
+    futures = client.map(get_chunk_metadata, granuales, access=access)
+    progress(futures)
+    chunks = client.gather(futures)
+    chunks = list(flatten(chunks))
+
+    # Write combined metadata file
+    mzz = MultiZarrToZarr(chunks, **kerchunk_options)
+    mzz.translate(outfile, storage_options=storage_options or {})
+
+    return outfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ s3fs = ">=2021.11, <2024"
 fsspec = ">=2022.1"
 tinynetrc = "^1.3.1"
 multimethod = ">=1.8"
+kerchunk = ">=0.1.2"
+dask = {extras = ["complete"], version = ">=2023.8.0"}
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
It can be prohibitively slow to read metadata for datasets from earthaccess for a few reasons (e.g. datasets are netcdf instead of zarr, https access is slow). @betolink has a nice description here https://discourse.pangeo.io/t/avoid-metadata-reads-when-loading-many-similar-netcdf-files/3594/5.

[Kerchunk](https://fsspec.github.io/kerchunk) helps the situation by doing a single pass over the dataset and creating a single, consolidated metadata file that can be used to quickly access the metadata for the full dataset in subsequent reads. Additionally, the initial pass over the dataset metadata can be parallelized, which helps further speed things up. 

This PR adds a new `earthaccess.consolidate_metadata(...)` utility for integrating `earthaccess` and `kerchunk` together to make it straightforwards for users to go through this metadata consolidation process for the datasets they're interested in. 

Here's an example of what this looks like in practice:

```python

import earthaccess
import xarray as xr
from dask.distributed import LocalCluster

if __name__ == "__main__":

    # Authenticate my machine with `earthaccess`
    earthaccess.login()

    # Retrieve data files for the dataset I'm interested in
    short_name = "SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205"
    granuales = earthaccess.search_data(
        short_name=short_name,
        cloud_hosted=True,
        temporal=("1990", "2019"),
        count=10,  # For demo purposes
    )

    # Create a local Dask cluster for parallel metadata consolidation
    # (but works with any Dask cluster)
    cluster = LocalCluster()
    client = cluster.get_client()

    # Save consolidated metdata file
    outfile = earthaccess.consolidate_metadata(
        granuales,
        outfile=f"./{short_name}-metadata.json",    # Writing to a local file for demo purposes
        # outfile=f"s3://my-bucket/{short_name}-metadata.json",   # We could also write to a remote file
        access="indirect",
        kerchunk_options={"concat_dims": "Time"}
    )
    print(f"Consolidated metadata written to {outfile}")

    # Load the dataset using the consolidated metadata file
    fs = earthaccess.get_fsspec_https_session()
    ds = xr.open_dataset(
        "reference://",
        engine="zarr",
        chunks={},
        backend_kwargs={
            "consolidated": False,
            "storage_options": {
                "fo": outfile,
                "remote_protocol": "https",
                "remote_options": fs.storage_options,
            }
        },
    )

    result = ds.SLA.mean({"Latitude", "Longitude"}).compute()
    print(f"{result = }")
```

cc @betolink for thoughts 