### PR TITLE
Fix ``test_dataset_search_returns_valid_results`` integration test

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -21,7 +21,7 @@ logger.info(f"earthaccess version: {earthaccess.__version__}")
 dataset_valid_params = [
     {"data_center": "NSIDC", "cloud_hosted": True},
     {"keyword": "aerosol", "cloud_hosted": False},
-    {"daac": "PODAAC", "keyword": "ocean"},
+    {"daac": "NSIDC", "keyword": "ocean"},
 ]
 
 granules_valid_params = [


### PR DESCRIPTION
`tests/integration/test_api.py::test_dataset_search_returns_valid_results` is failing on `main` with (e.g. see [this CI build](https://github.com/nsidc/earthaccess/actions/runs/6115023521/job/16597781359)): 

```
FAILED tests/integration/test_api.py::test_dataset_search_returns_valid_results[kwargs2] - IndexError: list index out of range
```

Changing the `daac` fixes the issue locally for me