### PR TITLE
Use CMR metadata to get S3FS sessions and authenticate queries to CMR using top level APIs

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -199,7 +199,7 @@ def open(
 def get_s3_credentials(
     daac: Optional[str] = None,
     provider: Optional[str] = None,
-    results: Optional[list[earthaccess.results.DataGranule]] = None,
+    results: Optional[List[earthaccess.results.DataGranule]] = None,
 ) -> Dict[str, Any]:
     """Returns temporary (1 hour) credentials for direct access to NASA S3 buckets, we can
     use the daac name, the provider or a list of results from earthaccess.search_data()

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -104,7 +104,10 @@ def search_data(
         )
         ```
     """
-    query = DataGranules().parameters(**kwargs)
+    if earthaccess.__auth__.authenticated:
+        query = DataGranules(earthaccess.__auth__).parameters(**kwargs)
+    else:
+        query = DataGranules().parameters(**kwargs)
     granules_found = query.hits()
     print(f"Granules found: {granules_found}")
     if count > 0:

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -7,8 +7,7 @@ from fsspec import AbstractFileSystem
 import earthaccess
 
 from .auth import Auth
-from .search import (CollectionQuery, DataCollections, DataGranules,
-                     GranuleQuery)
+from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery
 from .store import Store
 from .utils import _validation as validate
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -197,13 +197,19 @@ def open(
 
 
 def get_s3_credentials(
-    daac: Optional[str] = None, provider: Optional[str] = None
+    daac: Optional[str] = None,
+    provider: Optional[str] = None,
+    results: Optional[list[earthaccess.results.DataGranule]] = None,
 ) -> Dict[str, Any]:
-    """Returns temporary (1 hour) credentials for direct access to NASA S3 buckets
+    """Returns temporary (1 hour) credentials for direct access to NASA S3 buckets, we can
+    use the daac name, the provider or a list of results from earthaccess.search_data()
+    if we use results earthaccess will use the metadata on the response to get the credentials,
+    this is useful for missions that do not use the same endpoint as their DAACs e.g. SWOT
 
     Parameters:
-        daac: a DAAC short_name like NSIDC or PODAAC etc
-        provider: if we know the provider for the DAAC e.g. POCLOUD, LPCLOUD etc.
+        daac (String): a DAAC short_name like NSIDC or PODAAC etc
+        provider (String: if we know the provider for the DAAC e.g. POCLOUD, LPCLOUD etc.
+        results (list[earthaccess.results.DataGranule]): List of results from search_data()
     Returns:
         a dictionary with S3 credentials for the DAAC or provider
     """
@@ -211,6 +217,9 @@ def get_s3_credentials(
         daac = daac.upper()
     if provider is not None:
         provider = provider.upper()
+    if results is not None:
+        endpoint = results[0].get_s3_credentials_endpoint()
+        return earthaccess.__auth__.get_s3_credentials(endpoint=endpoint)
     return earthaccess.__auth__.get_s3_credentials(daac=daac, provider=provider)
 
 

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -138,7 +138,10 @@ class Auth(object):
         return False
 
     def get_s3_credentials(
-        self, daac: Optional[str] = "", provider: Optional[str] = ""
+        self,
+        daac: Optional[str] = None,
+        provider: Optional[str] = None,
+        endpoint: Optional[str] = None,
     ) -> Dict[str, str]:
         """Gets AWS S3 credentials for a given NASA cloud provider, the
         easier way is to use the DAAC short name. provider is optional if we know it.
@@ -146,6 +149,7 @@ class Auth(object):
         Parameters:
             provider: A valid cloud provider, each DAAC has a provider code for their cloud distributions
             daac: the name of a NASA DAAC, i.e. NSIDC or PODAAC
+            endpoint: getting the credentials directly from the S3Credentials URL
 
         Rreturns:
             A Python dictionary with the temporary AWS S3 credentials
@@ -153,7 +157,12 @@ class Auth(object):
         """
         if self.authenticated:
             session = SessionWithHeaderRedirection(self.username, self.password)
-            auth_url = self._get_cloud_auth_url(daac_shortname=daac, provider=provider)
+            if endpoint is None:
+                auth_url = self._get_cloud_auth_url(
+                    daac_shortname=daac, provider=provider
+                )
+            else:
+                auth_url = endpoint
             if auth_url.startswith("https://"):
                 cumulus_resp = session.get(auth_url, timeout=15, allow_redirects=True)
                 auth_resp = session.get(

--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -241,6 +241,12 @@ class DataGranule(CustomDict):
         granule_html_repr = _repr_granule_html(self)
         return granule_html_repr
 
+    def get_s3_credentials_endpoint(self) -> Union[str, None]:
+        for link in self["umm"]["RelatedUrls"]:
+            if "/s3credentials" in link["URL"]:
+                return link["URL"]
+        return None
+
     def size(self) -> float:
         """
         Returns:

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -121,7 +121,7 @@ class Store(object):
 
     def _own_s3_credentials(self, links: List[Dict[str, Any]]) -> Union[str, None]:
         for link in links:
-            if link["URL"].contains("/s3credentials"):
+            if "/s3credentials" in link["URL"]:
                 return link["URL"]
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "earthaccess"
-version = "0.5.3"
+version = "0.5.4"
 homepage = "https://github.com/nsidc/earthaccess"
 description = "Client library for NASA Earthdata APIs"
 authors = ["earthaccess contributors"]

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -55,6 +55,20 @@ class TestStoreSessions(unittest.TestCase):
     def test_store_can_create_s3_fsspec_session(self):
         from earthaccess.daac import DAACS
 
+        custom_endpoints = [
+            "https://archive.swot.podaac.earthdata.nasa.gov/s3credentials",
+            "https://api.giovanni.earthdata.nasa.gov/s3credentials",
+            "https://data.laadsdaac.earthdatacloud.nasa.gov/s3credentials",
+        ]
+
+        for endpoint in custom_endpoints:
+            responses.add(
+                responses.GET,
+                endpoint,
+                json={},
+                status=200,
+            )
+
         for daac in DAACS:
             if "s3-credentials" in daac:
                 responses.add(
@@ -78,6 +92,10 @@ class TestStoreSessions(unittest.TestCase):
         self.assertTrue(isinstance(store.auth, Auth))
         for daac in ["NSIDC", "PODAAC", "LPDAAC", "ORNLDAAC", "GES_DISC", "ASF"]:
             s3_fs = store.get_s3fs_session(daac=daac)
+            self.assertEqual(type(s3_fs), type(fsspec.filesystem("s3")))
+
+        for endpoint in custom_endpoints:
+            s3_fs = store.get_s3fs_session(endpoint=endpoint)
             self.assertEqual(type(s3_fs), type(fsspec.filesystem("s3")))
 
         for provider in [


### PR DESCRIPTION
This PR allows `earthacces.search_data()` and `earthaccess.search_dataset()` use the `auth` object to send bearer tokens to CMR, usually this is not required but in the case of restricted datasets or early release data CMR will only return results if we are in the access control lists for a given dataset. 

with this PR `earthaccess` will be able to use the metadata from CMR to grab S3 credentials, perhaps we need to simplify this even more but for now this works.

```python
import earthaccess

earthaccess.login()

results = earthaccess.search_data(
    short_name='SWOT_L2_HR_RIVERSP_1.0',
    cloud_hosted=True,
    bounding_box=(-10, 20, 10, 50),
    temporal=("1999-02", "2019-03"),
    count=10
)

# now earthaccess will use that the S3 credentials if they are present in the metadata if not it will grab the DAAC's
earrthaccess.open(results)

```

This code was failing because the SWOT mission has its own S3 credentials that are not from PODAAC.

another way of getting the authenticated sessions would be:

```python
if len(results) > 0:
    print(f"Actual granules returned: {len(results)}")    
    fs_s3 = earthaccess.get_s3fs_session(results=results)
```

And then we could use the storage_options to create authenticated sessions, this is the part that can be simplified:

```python
import fiona
from fiona.session import AWSSession

with fiona.Env(
    session=AWSSession(
        aws_access_key_id=fs_s3.storage_options["key"],
        aws_secret_access_key=fs_s3.storage_options["secret"],
        aws_session_token=fs_s3.storage_options["token"]
    )
):
    # some code  with gpd.read_file() etc
```