### PR TITLE
Update ``EarthAccessFile`` serialization logic

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict, List, Optional, Type, Union
 
+import earthaccess
 import requests
 import s3fs
 from fsspec import AbstractFileSystem
-
-import earthaccess
 
 from .auth import Auth
 from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -8,6 +8,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 from uuid import uuid4
+from pickle import loads
 
 import fsspec
 import requests
@@ -36,7 +37,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
             type(self.f),
             self.granule,
             earthaccess.__auth__,
-            self.f.__reduce__(),
+            dumps(self.f),
         )
 
     def __repr__(self) -> str:
@@ -65,7 +66,7 @@ def _open_files(
 
 
 def make_instance(
-    cls: Any, granule: DataGranule, auth: Auth, _reduce: Any
+    cls: Any, granule: DataGranule, auth: Auth, data: Any
 ) -> EarthAccessFile:
     # Attempt to re-authenticate
     if not earthaccess.__auth__.authenticated:
@@ -78,9 +79,7 @@ def make_instance(
         #       guaranteed to be the right one.
         return EarthAccessFile(earthaccess.open([granule])[0], granule)
     else:
-        func = _reduce[0]
-        args = _reduce[1]
-        return func(*args)
+        return EarthAccessFile(loads(data), granule)
 
 
 class Store(object):

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -73,7 +73,7 @@ def make_instance(
         earthaccess.__auth__ = auth
         earthaccess.login()
 
-    if earthaccess.__store__.running_in_aws and cls is not s3fs.S3File:
+    if (earthaccess.__store__.running_in_aws and cls is not s3fs.S3File) or (not earthaccess.__store__.running_in_aws and cls is s3fs.S3File):
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
         # NOTE: This uses the first data_link listed in the granule. That's not
         #       guaranteed to be the right one.

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -6,22 +6,21 @@ from copy import deepcopy
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from pickle import dumps, loads
+from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
-from pickle import loads, dumps
 
+import earthaccess
 import fsspec
 import requests
 import s3fs
 from multimethod import multimethod as singledispatchmethod
 from pqdm.threads import pqdm
 
-import earthaccess
-
+from .auth import Auth
 from .daac import DAAC_TEST_URLS, find_provider
 from .results import DataGranule
 from .search import DataCollections
-from .auth import Auth
 
 
 class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
@@ -73,7 +72,9 @@ def make_instance(
         earthaccess.__auth__ = auth
         earthaccess.login()
 
-    if (earthaccess.__store__.running_in_aws and cls is not s3fs.S3File) or (not earthaccess.__store__.running_in_aws and cls is s3fs.S3File):
+    if (earthaccess.__store__.running_in_aws and cls is not s3fs.S3File) or (
+        not earthaccess.__store__.running_in_aws and cls is s3fs.S3File
+    ):
         # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
         # NOTE: This uses the first data_link listed in the granule. That's not
         #       guaranteed to be the right one.

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -72,10 +72,11 @@ def make_instance(
         earthaccess.__auth__ = auth
         earthaccess.login()
 
+    # When sending EarthAccessFiles between processes, it's possible that
+    # we will need to switch between s3 <--> https protocols.
     if (earthaccess.__store__.running_in_aws and cls is not s3fs.S3File) or (
         not earthaccess.__store__.running_in_aws and cls is s3fs.S3File
     ):
-        # On AWS but not using a S3File. Reopen the file in this case for direct S3 access.
         # NOTE: This uses the first data_link listed in the granule. That's not
         #       guaranteed to be the right one.
         return EarthAccessFile(earthaccess.open([granule])[0], granule)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -8,7 +8,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 from uuid import uuid4
-from pickle import loads
+from pickle import loads, dumps
 
 import fsspec
 import requests


### PR DESCRIPTION
This PR update the ``EarthAccessFile`` pickle logic to handle the case that we're starting in region and sending a ``EarthAccessFile`` to a different process also in region. I had been testing the out of S3 to S3 code path when writing this code originally, but @betolink and I both ran into cases where this logic wasn't quite correct in other situations. I think this should now be correct. 
