### PR TITLE
Small store fixups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+* bug fixes:
+    * Fix spelling mistake in `access` variable assignment (`direc` -> `direct`)
+      in `earthaccess.store._get_granules`.
+    * Pass `threads` arg to `_open_urls_https` in
+      `earthaccess.store._open_urls`, replacing the hard-coded value of 8.
 
 ## [v0.6.0] 2023-09-20
 * bug fixes:

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -426,7 +426,7 @@ class Store(object):
                     "We cannot open S3 links when we are not in-region, try using HTTPS links"
                 )
                 return None
-            fileset = self._open_urls_https(data_links, granules, 8)
+            fileset = self._open_urls_https(data_links, granules, threads)
             return fileset
 
     def get(

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -533,7 +533,7 @@ class Store(object):
         provider = granules[0]["meta"]["provider-id"]
         endpoint = self._own_s3_credentials(granules[0]["umm"]["RelatedUrls"])
         cloud_hosted = granules[0].cloud_hosted
-        access = "direc" if (cloud_hosted and self.running_in_aws) else "external"
+        access = "direct" if (cloud_hosted and self.running_in_aws) else "external"
         data_links = list(
             # we are not in region
             chain.from_iterable(


### PR DESCRIPTION
Couple of minor fixups that I noticed while looking at `earthaccess.store`:

* Fixup spelling mistake in `access` variable assignment (`direc` -> `direct`)
* Pass `threads` arg to `_open_urls_https` in `_open_urls`, replacing hard-coded value of 8.