### PR TITLE
[DNM] Allow for opening with known file sizes

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -181,7 +181,7 @@ def download(
 def open(
     granules: Union[List[str], List[earthaccess.results.DataGranule]],
     provider: Optional[str] = None,
-    sizes=None,
+    sizes: Optional[List[int]] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of fsspec file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -181,6 +181,7 @@ def download(
 def open(
     granules: Union[List[str], List[earthaccess.results.DataGranule]],
     provider: Optional[str] = None,
+    sizes=None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of fsspec file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.
@@ -191,7 +192,9 @@ def open(
     Returns:
         a list of s3fs "file pointers" to s3 files.
     """
-    results = earthaccess.__store__.open(granules=granules, provider=provider)
+    results = earthaccess.__store__.open(
+        granules=granules, provider=provider, sizes=sizes
+    )
     return results
 
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -65,30 +65,6 @@ def _open_files(
                     "earthaccess will only open the first data link, "
                     "try filtering the links before opening them."
                 )
-        # if "s3" in str(type(fs)).lower() and size is not None:
-        #     # populate dircache
-        #     #   {'Key': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac',
-        #     #     'LastModified': datetime.datetime(2023, 9, 7, 1, 44, 9, tzinfo=tzutc()),
-        #     #     'ETag': '"4c2dd9323fd2bfca326e0032926a87e6"',
-        #     #     'Size': 298161,
-        #     #     'StorageClass': 'STANDARD',
-        #     #     'type': 'file',
-        #     #     'size': 298161,
-        #     #     'name': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac'}
-        #     for link in data_links:
-        #         name = fs._strip_protocol(link)
-        #         bucket, _ = os.path.split(name)
-        #         if bucket not in fs.dircache:
-        #             fs.dircache[bucket] = []
-        #         file_info = {
-        #             "name": name,
-        #             "Key": name,
-        #             "Size": size,
-        #             "size": size,
-        #             "StorageClass": "STANDARD",
-        #             "type": "file",
-        #         }
-        #         fs.dircache[bucket].append(file_info)
         return EarthAccessFile(fs.open(urls, size=size), granule)
 
     fileset = pqdm(zip(data_links, granules, sizes), multi_thread_open, n_jobs=threads)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -65,30 +65,30 @@ def _open_files(
                     "earthaccess will only open the first data link, "
                     "try filtering the links before opening them."
                 )
-        if "s3" in str(type(fs)).lower() and size is not None:
-            # populate dircache
-            #   {'Key': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac',
-            #     'LastModified': datetime.datetime(2023, 9, 7, 1, 44, 9, tzinfo=tzutc()),
-            #     'ETag': '"4c2dd9323fd2bfca326e0032926a87e6"',
-            #     'Size': 298161,
-            #     'StorageClass': 'STANDARD',
-            #     'type': 'file',
-            #     'size': 298161,
-            #     'name': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac'}
-            for link in data_links:
-                name = fs._strip_protocol(link)
-                bucket, _ = os.path.split(name)
-                if bucket not in fs.dircache:
-                    fs.dircache[bucket] = []
-                file_info = {
-                    "name": name,
-                    "Key": name,
-                    "Size": size,
-                    "size": size,
-                    "StorageClass": "STANDARD",
-                    "type": "file",
-                }
-                fs.dircache[bucket].append(file_info)
+        # if "s3" in str(type(fs)).lower() and size is not None:
+        #     # populate dircache
+        #     #   {'Key': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac',
+        #     #     'LastModified': datetime.datetime(2023, 9, 7, 1, 44, 9, tzinfo=tzutc()),
+        #     #     'ETag': '"4c2dd9323fd2bfca326e0032926a87e6"',
+        #     #     'Size': 298161,
+        #     #     'StorageClass': 'STANDARD',
+        #     #     'type': 'file',
+        #     #     'size': 298161,
+        #     #     'name': 'oss-scratch-space/jrbourbeau/arraylakef7947862d0a794abb85c0c4544fcf931acfbc21d5b02fec075fea05cfa3184ac'}
+        #     for link in data_links:
+        #         name = fs._strip_protocol(link)
+        #         bucket, _ = os.path.split(name)
+        #         if bucket not in fs.dircache:
+        #             fs.dircache[bucket] = []
+        #         file_info = {
+        #             "name": name,
+        #             "Key": name,
+        #             "Size": size,
+        #             "size": size,
+        #             "StorageClass": "STANDARD",
+        #             "type": "file",
+        #         }
+        #         fs.dircache[bucket].append(file_info)
         return EarthAccessFile(fs.open(urls, size=size), granule)
 
     fileset = pqdm(zip(data_links, granules, sizes), multi_thread_open, n_jobs=threads)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -51,10 +51,13 @@ def _open_files(
     granules: Union[List[str], List[DataGranule]],
     fs: fsspec.AbstractFileSystem,
     threads: Optional[int] = 8,
-    sizes=None,
+    sizes: Optional[List[int]] = None,
 ) -> List[fsspec.AbstractFileSystem]:
+    file_sizes: Union[List[int], List[None]]
     if sizes is None:
-        sizes = [None] * len(data_links)
+        file_sizes = [None] * len(data_links)
+    else:
+        file_sizes = sizes
 
     def multi_thread_open(data: tuple) -> EarthAccessFile:
         urls, granule, size = data
@@ -67,7 +70,9 @@ def _open_files(
                 )
         return EarthAccessFile(fs.open(urls, size=size), granule)
 
-    fileset = pqdm(zip(data_links, granules, sizes), multi_thread_open, n_jobs=threads)
+    fileset = pqdm(
+        zip(data_links, granules, file_sizes), multi_thread_open, n_jobs=threads
+    )
     return fileset
 
 
@@ -281,7 +286,7 @@ class Store(object):
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-        sizes=None,
+        sizes: Optional[List[int]] = None,
     ) -> Union[List[Any], None]:
         """Returns a list of fsspec file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
@@ -301,7 +306,7 @@ class Store(object):
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-        sizes=None,
+        sizes: Optional[List[int]] = None,
     ) -> Union[List[Any], None]:
         """Returns a list of fsspec file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
@@ -319,7 +324,7 @@ class Store(object):
         granules: List[DataGranule],
         provider: Optional[str] = None,
         threads: Optional[int] = 8,
-        sizes=None,
+        sizes: Optional[List[int]] = None,
     ) -> Union[List[Any], None]:
         fileset: List = []
         data_links: List = []
@@ -393,7 +398,7 @@ class Store(object):
         granules: List[str],
         provider: Optional[str] = None,
         threads: Optional[int] = 8,
-        sizes=None,
+        sizes: Optional[List[int]] = None,
     ) -> Union[List[Any], None]:
         fileset: List = []
         data_links: List = []
@@ -661,7 +666,7 @@ class Store(object):
         urls: List[str],
         granules: Union[List[str], List[DataGranule]],
         threads: Optional[int] = 8,
-        sizes=None,
+        sizes: Optional[List[int]] = None,
     ) -> List[fsspec.AbstractFileSystem]:
         https_fs = self.get_fsspec_session()
         if https_fs is not None:


### PR DESCRIPTION
The latest release of `s3fs` allows you to specify the file size ahead of time (if known) when opening an S3 file (this already existed for HTTPS files). This allows `s3fs` to skip some calls to S3 which can be expensive (especially when opening lots of files). Marking as DNM for now as I'm still experimenting with what performance impacts this has in practice.  