### PR TITLE
Add utility for getting authentication environment variables

### DIFF
--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -13,6 +13,7 @@ from .api import (
     open,
     search_data,
     search_datasets,
+    auth_environ,
 )
 from .auth import Auth
 from .search import DataCollections, DataGranules
@@ -34,6 +35,7 @@ __all__ = [
     "DataCollections",
     "Auth",
     "Store",
+    "auth_environ",
 ]
 
 __auth__ = Auth()

--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -2,6 +2,7 @@ from importlib.metadata import version
 from typing import Any
 
 from .api import (
+    auth_environ,
     collection_query,
     download,
     get_fsspec_https_session,
@@ -13,7 +14,6 @@ from .api import (
     open,
     search_data,
     search_datasets,
-    auth_environ,
 )
 from .auth import Auth
 from .search import DataCollections, DataGranules

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -331,8 +331,11 @@ def get_edl_token() -> str:
     token = earthaccess.__auth__.token
     return token
 
+
 def auth_environ() -> Dict[str, str]:
     auth = earthaccess.__auth__
     if not auth.authenticated:
-        raise RuntimeError("`auth_environ()` requires you to first authenticate with `earthaccess.login()`")
+        raise RuntimeError(
+            "`auth_environ()` requires you to first authenticate with `earthaccess.login()`"
+        )
     return {"EARTHDATA_USERNAME": auth.username, "EARTHDATA_PASSWORD": auth.password}

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -330,3 +330,9 @@ def get_edl_token() -> str:
     """
     token = earthaccess.__auth__.token
     return token
+
+def auth_environ() -> Dict[str, str]:
+    auth = earthaccess.__auth__
+    if not auth.authenticated:
+        raise RuntimeError("`auth_environ()` requires you to first authenticate with `earthaccess.login()`")
+    return {"EARTHDATA_USERNAME": auth.username, "EARTHDATA_PASSWORD": auth.password}

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -83,9 +83,14 @@ def test_earthaccess_api_can_download_granules():
     assertions.assertIsInstance(files, list)
     shutil.rmtree(local_path)
 
+
 def test_auth_environ():
     environ = earthaccess.auth_environ()
-    assert environ == {"EARTHDATA_USERNAME": os.environ["EARTHDATA_USERNAME"], "EARTHDATA_PASSWORD": os.environ["EARTHDATA_PASSWORD"]}
+    assert environ == {
+        "EARTHDATA_USERNAME": os.environ["EARTHDATA_USERNAME"],
+        "EARTHDATA_PASSWORD": os.environ["EARTHDATA_PASSWORD"],
+    }
+
 
 def test_auth_environ_raises(monkeypatch):
     monkeypatch.setattr(earthaccess.__auth__, "authenticated", False)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -82,3 +82,12 @@ def test_earthaccess_api_can_download_granules():
     files = earthaccess.download(results, local_path=local_path)
     assertions.assertIsInstance(files, list)
     shutil.rmtree(local_path)
+
+def test_auth_environ():
+    environ = earthaccess.auth_environ()
+    assert environ == {"EARTHDATA_USERNAME": os.environ["EARTHDATA_USERNAME"], "EARTHDATA_PASSWORD": os.environ["EARTHDATA_PASSWORD"]}
+
+def test_auth_environ_raises(monkeypatch):
+    monkeypatch.setattr(earthaccess.__auth__, "authenticated", False)
+    with pytest.raises(RuntimeError, match="authenticate"):
+        earthaccess.auth_environ()


### PR DESCRIPTION
When working with multiple machines, it's often easier to set authentication environment variables than it is to ship a `.netrc` file around. This PR adds a small utility for programmatically retrieving `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` 