### PR TITLE
Return S3 data links by default when in region

### DIFF
--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -301,7 +301,7 @@ class DataGranule(CustomDict):
         s3_links = self._filter_related_links("GET DATA VIA DIRECT ACCESS")
         if in_region:
             # we are in us-west-2
-            if self.cloud_hosted and access is None:
+            if self.cloud_hosted and access in (None, "direct"):
                 # this is a cloud collection and we didn't specify the access type
                 # default to S3 links
                 if len(s3_links) == 0 and len(https_links) > 0:
@@ -325,7 +325,6 @@ class DataGranule(CustomDict):
             else:
                 # we are not in us-west-2, even cloud collections have HTTPS links
                 return https_links
-        return https_links
 
     def dataviz_links(self) -> List[str]:
         """

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,0 +1,21 @@
+import earthaccess
+
+
+def test_data_links():
+    granules = earthaccess.search_data(
+        short_name="SEA_SURFACE_HEIGHT_ALT_GRIDS_L4_2SATS_5DAY_6THDEG_V_JPL2205",
+        temporal=("2020", "2022"),
+        count=1,
+    )
+    g = granules[0]
+    # `access` specified
+    assert g.data_links(access="direct")[0].startswith("s3://")
+    assert g.data_links(access="external")[0].startswith("https://")
+    # `in_region` specified
+    assert g.data_links(in_region=True)[0].startswith("s3://")
+    assert g.data_links(in_region=False)[0].startswith("https://")
+    # When `access` and `in_region` are both specified, `access` takes priority
+    assert g.data_links(access="direct", in_region=True)[0].startswith("s3://")
+    assert g.data_links(access="direct", in_region=False)[0].startswith("s3://")
+    assert g.data_links(access="external", in_region=True)[0].startswith("https://")
+    assert g.data_links(access="external", in_region=False)[0].startswith("https://")


### PR DESCRIPTION
I went to run the code referenced here https://github.com/nsidc/earthaccess/pull/316#issuecomment-1762014343 and got an error because it turns out `granule.data_links(access="direct", in_region=True)` returns a HTTPS link. This PR fixes that specific case and also makes it so `granule.data_links(in_region=True)` returns S3 links by default (which seems like it's the expected behavior, but @betolink @MattF-NSIDC let me know if you think otherwise).

I'm testing this PR out now to make sure if in fact fixes things 