### PR TITLE
Fix ``test_auth_environ_raises integration`` test

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -91,8 +91,9 @@ def test_auth_environ():
 
 
 def test_auth_environ_raises(monkeypatch):
-    # Temporarily ensure `earthaccess.__auth__` always returns a
-    # new, unauthenticated `earthaccess.Auth`` instance
+    # Ensure `earthaccess.__auth__` always returns a new,
+    # unauthenticated `earthaccess.Auth` instance, bypassing
+    # automatic auth behavior
     monkeypatch.setattr(earthaccess, "__auth__", earthaccess.Auth())
 
     # Ensure `earthaccess.auth_environ()` raises an informative error

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -91,6 +91,16 @@ def test_auth_environ():
 
 
 def test_auth_environ_raises(monkeypatch):
+    # Temporarily remove any existing authentication and make it so
+    # future attempts at authentication don't work
     monkeypatch.setattr(earthaccess.__auth__, "authenticated", False)
+
+    def bad_login(*args, **kwargs):
+        raise RuntimeError("Can't login")
+
+    monkeypatch.setattr(earthaccess.Auth, "login", bad_login)
+
+    # Ensure `earthaccess.auth_environ()` raises an informative error
+    # when not authenticated
     with pytest.raises(RuntimeError, match="authenticate"):
         earthaccess.auth_environ()

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -91,14 +91,9 @@ def test_auth_environ():
 
 
 def test_auth_environ_raises(monkeypatch):
-    # Temporarily remove any existing authentication and make it so
-    # future attempts at authentication don't work
-    monkeypatch.setattr(earthaccess.__auth__, "authenticated", False)
-
-    def bad_login(*args, **kwargs):
-        raise RuntimeError("Can't login")
-
-    monkeypatch.setattr(earthaccess.Auth, "login", bad_login)
+    # Temporarily ensure `earthaccess.__auth__` always returns a
+    # new, unauthenticated `earthaccess.Auth`` instance
+    monkeypatch.setattr(earthaccess, "__auth__", earthaccess.Auth())
 
     # Ensure `earthaccess.auth_environ()` raises an informative error
     # when not authenticated


### PR DESCRIPTION
This is currently failing on `main` with `FAILED tests/integration/test_api.py::test_auth_environ_raises - Failed: DID NOT RAISE <class 'RuntimeError'>`  (for example, see [this CI build](https://github.com/nsidc/earthaccess/actions/runs/6538911512/job/17763073681)) due to the new automatic authentication update (xref https://github.com/nsidc/earthaccess/pull/300). 

This PR update this test accordingly so it passes while still keeping the original intent of the test