### PR TITLE
Switch GitHub Pages deployment method/source to GitHub Actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  documentation:
+  build-documentation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -55,13 +55,22 @@ jobs:
         env:
           EARTHDATA_USERNAME: ${{ secrets.EDL_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EDL_PASSWORD }}
-
-      - name: Deploy
-        if: |
-          github.event_name == 'push'
-          && (github.ref == 'refs/heads/main' || github.ref == 'ref/heads/documentation')
-          && github.repository == 'nsidc/earthaccess'
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          path: ./site
+
+  deploy-documentation:
+    if: |
+      github.event_name == 'push'
+      && (github.ref == 'refs/heads/main' || github.ref == 'ref/heads/documentation')
+      && github.repository == 'nsidc/earthaccess'
+    runs-on: ubuntu-latest
+    needs: documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,7 +66,7 @@ jobs:
       && (github.ref == 'refs/heads/main' || github.ref == 'ref/heads/documentation')
       && github.repository == 'nsidc/earthaccess'
     runs-on: ubuntu-latest
-    needs: documentation
+    needs: build-documentation
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
closes #323 , related to #277, will probably conflict with #324 :)

I really don't like dealing with an extra branch in my source repo for something that _is not source_. What do you all think?

This requires a change in the Pages admin panel:

![image](https://github.com/nsidc/earthaccess/assets/3608264/066c1419-4dde-4b47-942f-85f3e5d488d3)
