### PR TITLE
Fix: Assume granules without `RelatedUrls` are not cloud hosted

### DIFF
--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -491,6 +491,10 @@ class DataGranules(GranuleQuery):
         return True
 
     def _is_cloud_hosted(self, granule: Any) -> bool:
+        """Check if a granule record in CMR advertises "direct access"."""
+        if "RelatedUrls" not in granule["umm"]:
+            return False
+
         direct_def = "GET DATA VIA DIRECT ACCESS"
         for link in granule["umm"]["RelatedUrls"]:
             if "protected" in link["URL"] or link["Type"] == direct_def:


### PR DESCRIPTION
Resolves #338

We have a similar check in `results.py`: https://github.com/nsidc/earthaccess/blob/8461cfa1302d1186be88d5067c24531d5bde9be7/earthaccess/results.py#L51-L52


I'm going to want to release ASAP to support [Antarctica Today](https://github.com/nsidc/antarctica_today).