### PR TITLE
Migrate tool configs to pyproject.toml, configure pre-commit.ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,7 @@ name: Unit Tests
 
 on:
   push:
-    paths:
-      - earthaccess/**
-      - tests/**
   pull_request:
-    paths:
-      - earthaccess/**
-      - tests/**
     types: [opened, synchronize]
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,17 @@
+ci:
+  autoupdate_schedule: "monthly"  # Like dependabot
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_prs: false  # Comment "pre-commit.ci autofix" on a PR to trigger
+
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-    -   id: check-yaml
-    -   id: trailing-whitespace
-    -   id: check-toml
-    -   id: check-json
--   repo: https://github.com/psf/black
-    rev: 20.8b1
-    hooks:
-    -   id: black
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+    - id: check-yaml
+    - id: trailing-whitespace
+    - id: check-toml
+    - id: check-json
+- repo: https://github.com/psf/black
+  rev: 20.8b1
+  hooks:
+    - id: black

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,0 @@
-[mypy]
-disallow_untyped_defs = True
-ignore_missing_imports = True
-[mypy-tests.*]
-ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,17 @@ build-backend = "poetry.masonry.api"
 filterwarnings = ["error::UserWarning"]
 
 
+[tool.mypy]
+disallow_untyped_defs = false
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = [
+  "tests.*",
+]
+ignore_errors = true
+
+
 [tool.bumpversion]
 current_version = "0.7.0"
 commit = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
 
+[tool.pytest]
+filterwarnings = ["error::UserWarning"]
+
+
 [tool.bumpversion]
 current_version = "0.7.0"
 commit = false

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-filterwarnings =
-    error::UserWarning


### PR DESCRIPTION
Pytest and Mypy can both be configured by `pyproject.toml`. 

[Flake8 can't](https://github.com/PyCQA/flake8/issues/234), but Ruff can. I prefer Ruff anyway, so I opened #341.