### PR TITLE
Allow single file URL inputs for ``earthaccess.download``

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from typing import Any, Dict, List, Optional, Type, Union
 
 import earthaccess
 import requests
@@ -170,8 +170,10 @@ def download(
     Returns:
         List of downloaded files
     """
-    if isinstance(granules, (DataGranule, str)):
-        granules = cast(Union[List[DataGranule], List[str]], [granules])
+    if isinstance(granules, DataGranule):
+        granules = [granules]
+    elif isinstance(granules, str):
+        granules = [granules]
     try:
         results = earthaccess.__store__.get(granules, local_path, provider, threads)
     except AttributeError as err:

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type, Union, cast
 
 import earthaccess
 import requests
@@ -151,7 +151,7 @@ def login(strategy: str = "all", persist: bool = False) -> Auth:
 
 
 def download(
-    granules: Union[DataGranule, List[DataGranule], List[str]],
+    granules: Union[DataGranule, List[DataGranule], str, List[str]],
     local_path: Union[str, None],
     provider: Optional[str] = None,
     threads: int = 8,
@@ -162,7 +162,7 @@ def download(
        * If we run it outside AWS (us-west-2 region) and the dataset is cloud hostes we'll use HTTP links
 
     Parameters:
-        granules: a granule, list of granules, or a list of granule links (HTTP)
+        granules: a granule, list of granules, a granule link (HTTP), or a list of granule links (HTTP)
         local_path: local directory to store the remote data granules
         provider: if we download a list of URLs we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
@@ -170,8 +170,8 @@ def download(
     Returns:
         List of downloaded files
     """
-    if isinstance(granules, DataGranule):
-        granules = [granules]
+    if isinstance(granules, (DataGranule, str)):
+        granules = cast(Union[List[DataGranule], List[str]], [granules])
     try:
         results = earthaccess.__store__.get(granules, local_path, provider, threads)
     except AttributeError as err:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -69,13 +69,18 @@ def test_granules_search_returns_valid_results(kwargs):
 
 
 @pytest.mark.parametrize("selection", [0, slice(None)])
-def test_earthaccess_api_can_download_granules(tmp_path, selection):
+@pytest.mark.parametrize("use_url", [True, False])
+def test_download(tmp_path, selection, use_url):
     results = earthaccess.search_data(
         count=2,
         short_name="ATL08",
         cloud_hosted=True,
         bounding_box=(-92.86, 16.26, -91.58, 16.97),
     )
+    if use_url:
+        # Download via file URL instead of granule
+        results = [r.data_links(access="indirect") for r in results]
+        results = sum(results, start=[])  # flatten to a list of strings
     result = results[selection]
     files = earthaccess.download(result, str(tmp_path))
     assertions.assertIsInstance(files, list)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -78,7 +78,7 @@ def test_download(tmp_path, selection, use_url):
         bounding_box=(-92.86, 16.26, -91.58, 16.97),
     )
     if use_url:
-        # Download via file URL instead of granule
+        # Download via file URL string instead of DataGranule object
         results = [r.data_links(access="indirect") for r in results]
         results = sum(results, start=[])  # flatten to a list of strings
     result = results[selection]


### PR DESCRIPTION
Similar to https://github.com/nsidc/earthaccess/pull/317 but for a single `https://...` URL instead of a single data granule