### PR TITLE
Raise exceptions more

### DIFF
--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -230,10 +230,9 @@ class Store(object):
                 self.initial_ts = datetime.datetime.now()
             return deepcopy(self.s3_fs)
         else:
-            print(
+            raise ValueError(
                 "A valid Earthdata login instance is required to retrieve S3 credentials"
             )
-            return None
 
     @lru_cache
     def get_fsspec_session(self) -> fsspec.AbstractFileSystem:
@@ -269,7 +268,7 @@ class Store(object):
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-    ) -> Union[List[Any], None]:
+    ) -> List[Any]:
         """Returns a list of fsspec file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
 
@@ -280,15 +279,14 @@ class Store(object):
         """
         if len(granules):
             return self._open(granules, provider)
-        print("The granules list is empty, moving on...")
-        return None
+        return []
 
     @singledispatchmethod
     def _open(
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-    ) -> Union[List[Any], None]:
+    ) -> List[Any]:
         """Returns a list of fsspec file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
 
@@ -305,17 +303,16 @@ class Store(object):
         granules: List[DataGranule],
         provider: Optional[str] = None,
         threads: Optional[int] = 8,
-    ) -> Union[List[Any], None]:
+    ) -> List[Any]:
         fileset: List = []
         data_links: List = []
         total_size = round(sum([granule.size() for granule in granules]) / 1024, 2)
-        print(f" Opening {len(granules)} granules, approx size: {total_size} GB")
+        print(f"Opening {len(granules)} granules, approx size: {total_size} GB")
 
         if self.auth is None:
-            print(
+            raise ValueError(
                 "A valid Earthdata login instance is required to retrieve credentials"
             )
-            return None
 
         if self.running_in_aws:
             if granules[0].cloud_hosted:
@@ -347,13 +344,12 @@ class Store(object):
                         fs=s3_fs,
                         threads=threads,
                     )
-                except Exception:
-                    print(
-                        "An exception occurred while trying to access remote files on S3: "
-                        "This may be caused by trying to access the data outside the us-west-2 region"
+                except Exception as e:
+                    raise RuntimeError(
+                        "An exception occurred while trying to access remote files on S3. "
+                        "This may be caused by trying to access the data outside the us-west-2 region."
                         f"Exception: {traceback.format_exc()}"
-                    )
-                    return None
+                    ) from e
             else:
                 fileset = self._open_urls_https(data_links, granules, threads=threads)
             return fileset
@@ -373,7 +369,7 @@ class Store(object):
         granules: List[str],
         provider: Optional[str] = None,
         threads: Optional[int] = 8,
-    ) -> Union[List[Any], None]:
+    ) -> List[Any]:
         fileset: List = []
         data_links: List = []
 
@@ -384,15 +380,13 @@ class Store(object):
             provider = provider
             data_links = granules
         else:
-            print(
+            raise ValueError(
                 f"Schema for {granules[0]} is not recognized, must be an HTTP or S3 URL"
             )
-            return None
         if self.auth is None:
-            print(
+            raise ValueError(
                 "A valid Earthdata login instance is required to retrieve S3 credentials"
             )
-            return None
 
         if self.running_in_aws and granules[0].startswith("s3"):
             if provider is not None:
@@ -405,27 +399,24 @@ class Store(object):
                             fs=s3_fs,
                             threads=threads,
                         )
-                    except Exception:
-                        print(
-                            "An exception occurred while trying to access remote files on S3: "
-                            "This may be caused by trying to access the data outside the us-west-2 region"
+                    except Exception as e:
+                        raise RuntimeError(
+                            "An exception occurred while trying to access remote files on S3. "
+                            "This may be caused by trying to access the data outside the us-west-2 region."
                             f"Exception: {traceback.format_exc()}"
-                        )
-                        return None
+                        ) from e
                 else:
                     print(f"Provider {provider} has no valid cloud credentials")
                 return fileset
             else:
-                print(
+                raise ValueError(
                     "earthaccess cannot derive the DAAC provider from URLs only, a provider is needed e.g. POCLOUD"
                 )
-                return None
         else:
             if granules[0].startswith("s3"):
-                print(
+                raise ValueError(
                     "We cannot open S3 links when we are not in-region, try using HTTPS links"
                 )
-                return None
             fileset = self._open_urls_https(data_links, granules, threads)
             return fileset
 
@@ -435,7 +426,7 @@ class Store(object):
         local_path: Optional[str] = None,
         provider: Optional[str] = None,
         threads: int = 8,
-    ) -> Union[None, List[str]]:
+    ) -> List[str]:
         """Retrieves data granules from a remote storage system.
 
            * If we run this in the cloud we are moving data from S3 to a cloud compute instance (EC2, AWS Lambda)
@@ -463,8 +454,7 @@ class Store(object):
             files = self._get(granules, local_path, provider, threads)
             return files
         else:
-            print("List of URLs or DataGranule isntances expected")
-            return None
+            raise ValueError("List of URLs or DataGranule isntances expected")
 
     @singledispatchmethod
     def _get(
@@ -473,7 +463,7 @@ class Store(object):
         local_path: str,
         provider: Optional[str] = None,
         threads: int = 8,
-    ) -> Union[None, List[str]]:
+    ) -> List[str]:
         """Retrieves data granules from a remote storage system.
 
            * If we run this in the cloud we are moving data from S3 to a cloud compute instance (EC2, AWS Lambda)
@@ -491,8 +481,7 @@ class Store(object):
         Returns:
             None
         """
-        print("List of URLs or DataGranule isntances expected")
-        return None
+        raise NotImplementedError(f"Cannot _get {granules}")
 
     @_get.register
     def _get_urls(
@@ -501,15 +490,14 @@ class Store(object):
         local_path: str,
         provider: Optional[str] = None,
         threads: int = 8,
-    ) -> Union[None, List[str]]:
+    ) -> List[str]:
         data_links = granules
         downloaded_files: List = []
         if provider is None and self.running_in_aws and "cumulus" in data_links[0]:
-            print(
+            raise ValueError(
                 "earthaccess can't yet guess the provider for cloud collections, "
                 "we need to use one from earthaccess.list_cloud_providers()"
             )
-            return None
         if self.running_in_aws and data_links[0].startswith("s3"):
             print(f"Accessing cloud dataset using provider: {provider}")
             s3_fs = self.get_s3fs_session(provider=provider)
@@ -532,7 +520,7 @@ class Store(object):
         local_path: str,
         provider: Optional[str] = None,
         threads: int = 8,
-    ) -> Union[None, List[str]]:
+    ) -> List[str]:
         data_links: List = []
         downloaded_files: List = []
         provider = granules[0]["meta"]["provider-id"]
@@ -615,13 +603,11 @@ class Store(object):
         :returns: None
         """
         if urls is None:
-            print("The granules didn't provide a valid GET DATA link")
-            return None
+            raise ValueError("The granules didn't provide a valid GET DATA link")
         if self.auth is None:
-            print(
+            raise ValueError(
                 "We need to be logged into NASA EDL in order to download data granules"
             )
-            return []
         if not os.path.exists(directory):
             os.makedirs(directory)
 


### PR DESCRIPTION
There are a few places where we're currently printing a message and returning `None`, `[]`, etc. when something goes wrong. It's nice that there's typically an informative message, but it relatively easy to ignore these messages (guilty myself), and can lead to unexpected downstream errors (e.g. downstream code is expecting a list of strings, but you give it `None` instead).

Here's an example

```python
In [5]: result = earthaccess.open(["notavalidprotocol://myfile.nc"])
Schema for notavalidprotocol://myfile.nc is not recognized, must be an HTTP or S3 URL

In [6]: type(result)
Out[6]: NoneType
```

This PR proposes we raise exceptions in these cases (still with an informative message) to properly signal "Hey, something went wrong here". This should make it more clear where things are going awry. 

With the changes in this PR, the above example looks like this instead 

```python
In [2]: result = earthaccess.open(["notavalidprotocol://myfile.nc"])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 result = earthaccess.open(["notavalidprotocol://myfile.nc"])

File ~/projects/nsidc/earthaccess/earthaccess/api.py:197, in open(granules, provider)
    184 def open(
    185     granules: Union[List[str], List[earthaccess.results.DataGranule]],
    186     provider: Optional[str] = None,
    187 ) -> List[AbstractFileSystem]:
    188     """Returns a list of fsspec file-like objects that can be used to access files
    189     hosted on S3 or HTTPS by third party libraries like xarray.
    190
   (...)
    195         a list of s3fs "file pointers" to s3 files.
    196     """
--> 197     results = earthaccess.__store__.open(granules=granules, provider=provider)
    198     return results

File ~/projects/nsidc/earthaccess/earthaccess/store.py:281, in Store.open(self, granules, provider)
    272 """Returns a list of fsspec file-like objects that can be used to access files
    273 hosted on S3 or HTTPS by third party libraries like xarray.
    274
   (...)
    278     a list of s3fs "file pointers" to s3 files.
    279 """
    280 if len(granules):
--> 281     return self._open(granules, provider)
    282 return []

File ~/mambaforge/envs/earthaccess-dev/lib/python3.9/site-packages/multimethod/__init__.py:315, in multimethod.__call__(self, *args, **kwargs)
    313 func = self[tuple(func(arg) for func, arg in zip(self.type_checkers, args))]
    314 try:
--> 315     return func(*args, **kwargs)
    316 except TypeError as ex:
    317     raise DispatchError(f"Function {func.__code__}") from ex

File ~/projects/nsidc/earthaccess/earthaccess/store.py:383, in Store._open_urls(self, granules, provider, threads)
    381     data_links = granules
    382 else:
--> 383     raise ValueError(
    384         f"Schema for {granules[0]} is not recognized, must be an HTTP or S3 URL"
    385     )
    386 if self.auth is None:
    387     raise ValueError(
    388         "A valid Earthdata login instance is required to retrieve S3 credentials"
    389     )

ValueError: Schema for notavalidprotocol://myfile.nc is not recognized, must be an HTTP or S3 URL
```

Which seems more like what I'd expect. 