### PR TITLE
Feature/issue 357

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [unreleased]
+* Fix zero granules being reported for restricted datasets
+
 ## [v0.7.1] 2023-11-08
 * Bug Fixes:
     * Treat granules without `RelatedUrls` as not cloud-hosted.

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -328,7 +328,7 @@ class DataGranules(GranuleQuery):
 
         url = self._build_url()
 
-        response = self.session.get(url, headers=self.headers, params={'page_size': 0})
+        response = self.session.get(url, headers=self.headers, params={"page_size": 0})
 
         try:
             response.raise_for_status()

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -58,7 +58,7 @@ class DataCollections(CollectionQuery):
 
 
         Returns:
-            number of results reproted by CMR
+            number of results reported by CMR
         """
         return super().hits()
 

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -318,6 +318,25 @@ class DataGranules(GranuleQuery):
 
         self._debug = False
 
+    def hits(self):
+        """
+        Returns the number of hits the current query will return. This is done by
+        making a lightweight query to CMR and inspecting the returned headers.
+
+        :returns: number of results reported by CMR
+        """
+
+        url = self._build_url()
+
+        response = self.session.get(url, headers=self.headers, params={'page_size': 0})
+
+        try:
+            response.raise_for_status()
+        except exceptions.HTTPError as ex:
+            raise RuntimeError(ex.response.text)
+
+        return int(response.headers["CMR-Hits"])
+
     def parameters(self, **kwargs: Any) -> Type[CollectionQuery]:
         """Provide query parameters as keyword arguments. The keyword needs to match the name
         of the method, and the value should either be the value or a tuple of values.

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -318,7 +318,7 @@ class DataGranules(GranuleQuery):
 
         self._debug = False
 
-    def hits(self):
+    def hits(self) -> int:
         """
         Returns the number of hits the current query will return. This is done by
         making a lightweight query to CMR and inspecting the returned headers.


### PR DESCRIPTION
Addresses #357.

## Description

This change adds a `hits()` method to the `DataGranule` class, which uses the authenticated session. This overrides the `hits()` method from the `Query` base class, which does not use an authenticated session.

The reason for this change is to enable `earthaccess` to correctly determine and report the number of granules for "restricted" datasets, which are collections that only permit access if a user's authenticated Earthdata login (EDL) belongs to an Access Control List (ACL).

## Local test steps
Ran `earthaccess.search()` on a TEMPO data collection that is not public but for which my EDL belonged to an ACL, and confirmed that an appropriate non-zero number of granules was returned. And I was able to subsequently work with the data via `earthaccess.open()` and `xarray` functions.
