### PR TITLE
Enable AWS check with IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Bug fixes:
+    * Follow Amazon EC2 IMDSv2 requirements to set `running-in-aws`
+
 ## [v0.8.1] 2023-12-01
 * New Features:
     * Add `kerchunk` metadata consolidation utility.

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -140,8 +140,10 @@ class Store(object):
         session = self.auth.get_session()
         try:
             # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
-            resp = session.get(
-                "http://169.254.169.254/latest/meta-data/public-ipv4", timeout=1
+            resp = session.put(
+                "http://169.254.169.254/latest/api/token",
+                headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+                timeout=1,
             )
         except Exception:
             return False


### PR DESCRIPTION
Fixes #390 with a small change to the check for instance metadata query. For IMDSv2, the first request must be a PUT to "http://169.254.169.254/latest/api/token". A Response OK on that seems like a sufficient check.

Tests ... I would love to add a test. I have no idea how a test that depends on running on an EC2 instance could be set up. If you would like to provide guidance, happy to tackle.