### PR TITLE
Add region to running in AWS check

### DIFF
--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -141,11 +141,13 @@ class Store(object):
         try:
             # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html
             resp = session.get(
-                "http://169.254.169.254/latest/meta-data/public-ipv4", timeout=1
+                "http://169.254.169.254/latest/meta-data/placement/region", timeout=1
             )
         except Exception:
             return False
-        if resp.status_code == 200:
+
+        if resp.status_code == 200 and b"us-west-2" == resp.content:
+            # On AWS in region us-west-2
             return True
         return False
 


### PR DESCRIPTION
I noticed that right now we're just checking whether or not one is running in AWS in any region. This can lead to errors when attempting to open granules on AWS, but in a region outside of `us-west-2`. This PR updated our `_am_i_in_aws()` check to check that the region is `us-west-2` to avoid these types of errors. 