### PR TITLE
Add `python-dateutil` as a direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ s3fs = ">=2021.11, <2024"
 fsspec = ">=2022.1"
 tinynetrc = "^1.3.1"
 multimethod = ">=1.8"
+python-dateutil = ">=2.8.2"
 kerchunk = { version = ">=0.1.2", optional = true }
 dask = { version = ">=2022.1.0", optional = true }
 


### PR DESCRIPTION
Closes https://github.com/nsidc/earthaccess/issues/392

cc @mfisher87 