### PR TITLE
Add workflow to update PRs with docs preview link in description

### DIFF
--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -1,0 +1,19 @@
+# The ReadTheDocs preview link is "hidden" within the GitHub "Checks"
+# interface. For users who don't know this, finding the preview link may be
+# very difficult or frustrating. This workflow makes the link more
+# findable by updating PR descriptions to include it.
+name: "Add ReadTheDocs preview link to PR descriptions"
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: "write"
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "readthedocs/actions/preview@v1"
+        with:
+          project-slug: "earthaccess"

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -6,6 +6,8 @@ name: "Add ReadTheDocs preview link to PR descriptions"
 
 on:
   pull_request_target:
+    types:
+       - opened
 
 permissions:
   pull-requests: "write"

--- a/.github/workflows/pr-rtd-link.yml
+++ b/.github/workflows/pr-rtd-link.yml
@@ -7,7 +7,7 @@ name: "Add ReadTheDocs preview link to PR descriptions"
 on:
   pull_request_target:
     types:
-       - opened
+      - opened
 
 permissions:
   pull-requests: "write"


### PR DESCRIPTION
This improves accessibility by removing the need to know in advance where to find the ReadTheDocs link in the GitHub PR interface. 

See demo: https://github.com/mfisher87/earthaccess/pull/11 (the link doesn't work because RTD isn't set up for my fork ;) )