### PR TITLE
add us-west-2 check to API and improve auth repr

### DIFF
--- a/earthaccess/__init__.py
+++ b/earthaccess/__init__.py
@@ -10,11 +10,13 @@ from .api import (
     get_requests_https_session,
     get_s3_credentials,
     get_s3fs_session,
+    get_edl_token,
     granule_query,
     login,
     open,
     search_data,
     search_datasets,
+    in_us_west_2,
 )
 from .auth import Auth
 from .kerchunk import consolidate_metadata
@@ -24,6 +26,7 @@ from .store import Store
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    # api.py
     "login",
     "search_datasets",
     "search_data",
@@ -31,15 +34,21 @@ __all__ = [
     "get_fsspec_https_session",
     "get_s3fs_session",
     "get_s3_credentials",
+    "get_edl_token"
     "granule_query",
     "collection_query",
     "open",
     "download",
+    "auth_environ",
+    "in_us_west_2",
+    # search.py
     "DataGranules",
     "DataCollections",
+    # auth.py
     "Auth",
+    # store.py
     "Store",
-    "auth_environ",
+    # kerchunk
     "consolidate_metadata",
 ]
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -362,3 +362,12 @@ def auth_environ() -> Dict[str, str]:
             "`auth_environ()` requires you to first authenticate with `earthaccess.login()`"
         )
     return {"EARTHDATA_USERNAME": auth.username, "EARTHDATA_PASSWORD": auth.password}
+
+
+def in_us_west_2() -> bool:
+    """Returns true if the user is in AWS region us-west-2
+
+    Returns:
+        bool: boolean indicating if the user is in AWS region us-west-2
+    """
+    return earthaccess.__store__._running_in_us_west_2()

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -364,10 +364,14 @@ def auth_environ() -> Dict[str, str]:
     return {"EARTHDATA_USERNAME": auth.username, "EARTHDATA_PASSWORD": auth.password}
 
 
-def in_us_west_2() -> bool:
+def in_us_west_2() -> str:
     """Returns true if the user is in AWS region us-west-2
 
     Returns:
-        bool: boolean indicating if the user is in AWS region us-west-2
+        str: string indicating if the user is in AWS region us-west-2
     """
-    return earthaccess.__store__._running_in_us_west_2()
+    if earthaccess.__store__._running_in_us_west_2() is True:
+        msg = "You are running in AWS region 'us-west-2'"
+    else: 
+        msg = "You are not running in AWS region 'us-west-2'"
+    return msg

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -62,9 +62,9 @@ class Auth(object):
         self.EDL_GENERATE_TOKENS_URL = "https://urs.earthdata.nasa.gov/api/users/token"
         self.EDL_REVOKE_TOKEN = "https://urs.earthdata.nasa.gov/api/users/revoke_token"
 
-    def __str__(self) -> str:
-        print_str = "Authentication Info\n" + "----------\n"
-        for k, v in self.auth_info:
+    def __repr__(self) -> str:
+        print_str = "Authentication Info\n" + "-------------------\n"
+        for k, v in self.auth_info.items():
             print_str += str("{}: {}\n".format(k, v))
 
         return print_str
@@ -81,11 +81,6 @@ class Auth(object):
             "authenticated?": self.authenticated,
             "tokens": self.tokens,
         }
-
-        #modify this to get the region check if in s3
-        # add a separate in uswest2 access point to api?
-        if "Region" in self.s3_bucket():
-            summary_dict["cloud-info"] = self.s3_bucket()
 
         return summary_dict
 

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -62,6 +62,33 @@ class Auth(object):
         self.EDL_GENERATE_TOKENS_URL = "https://urs.earthdata.nasa.gov/api/users/token"
         self.EDL_REVOKE_TOKEN = "https://urs.earthdata.nasa.gov/api/users/revoke_token"
 
+    def __str__(self) -> str:
+        print_str = "Authentication Info\n" + "----------\n"
+        for k, v in self.auth_info:
+            print_str += str("{}: {}\n".format(k, v))
+
+        return print_str
+
+    @property
+    def auth_info(self) -> Dict:
+        """Get information about the authentication session
+
+        Returns:
+            Dict: information about the auth object
+        """
+        summary_dict: Dict[str, Any]
+        summary_dict = {
+            "authenticated?": self.authenticated,
+            "tokens": self.tokens,
+        }
+
+        #modify this to get the region check if in s3
+        # add a separate in uswest2 access point to api?
+        if "Region" in self.s3_bucket():
+            summary_dict["cloud-info"] = self.s3_bucket()
+
+        return summary_dict
+
     def login(self, strategy: str = "netrc", persist: bool = False) -> Any:
         """Authenticate with Earthdata login
 
@@ -154,7 +181,7 @@ class Auth(object):
             daac: the name of a NASA DAAC, i.e. NSIDC or PODAAC
             endpoint: getting the credentials directly from the S3Credentials URL
 
-        Rreturns:
+        Returns:
             A Python dictionary with the temporary AWS S3 credentials
 
         """


### PR DESCRIPTION
Per #231, we've added API access to `store._running_in_us_west_2()` in the form of a printed statement that the user is (or is not) running in AWS region us-west-2. In the process of implementing this, it became clear that `get_edl_token()` had not been added to `__init__.py`, so that was added as well. It also adds a repr for the `auth` object via a `auth.auth_info()` property.

I'm seeking input on:
- if this PR fully satisfies #231 - was the spirit to check specifically for us-west-2, or to enable the user to see what region they are running in? Pending that answer, it might make sense to have a more generic "earthaccess.region()` function instead.
- What should be in `auth.__repr__`? Currently it's not much better than the object ID:
```
Authentication Info
-------------------
authenticated?: True
tokens: [{'access_token': 'eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJzaWciOiJlZGxqd3RwdWJrZXlfb3BzIiwiY[truncated]...', 'token_type': 'Bearer', 'expiration_date': '02/09/2024'}]```