### PR TITLE
allow datetime object to be provided for temporal queries

### DIFF
--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from inspect import getmembers, ismethod
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import dateutil.parser as parser  # type: ignore
 from cmr import CollectionQuery, GranuleQuery  # type: ignore
@@ -262,31 +262,36 @@ class DataCollections(CollectionQuery):
         return results
 
     def temporal(
-        self, date_from: str, date_to: str, exclude_boundary: bool = False
+        self,
+        date_from: Optional[Union[str, dt.datetime]] = None,
+        date_to: Optional[Union[str, dt.datetime]] = None,
+        exclude_boundary: bool = False,
     ) -> Type[CollectionQuery]:
         """Filter by an open or closed date range. Dates can be provided as datetime objects
         or ISO 8601 formatted strings. Multiple ranges can be provided by successive calls.
         to this method before calling execute().
 
         Parameters:
-            date_from (String): earliest date of temporal range
-            date_to (string): latest date of temporal range
+            date_from (String or Datetime object): earliest date of temporal range
+            date_to (String or Datetime object): latest date of temporal range
             exclude_boundary (Boolean): whether or not to exclude the date_from/to in the matched range
         """
         DEFAULT = dt.datetime(1979, 1, 1)
-        if date_from is not None:
+        if date_from is not None and not isinstance(date_from, dt.datetime):
             try:
-                parsed_from = parser.parse(date_from, default=DEFAULT).isoformat() + "Z"
+                date_from = parser.parse(date_from, default=DEFAULT).isoformat() + "Z"
             except Exception:
                 print("The provided start date was not recognized")
-                parsed_from = ""
-        if date_to is not None:
+                date_from = ""
+
+        if date_to is not None and not isinstance(date_to, dt.datetime):
             try:
-                parsed_to = parser.parse(date_to, default=DEFAULT).isoformat() + "Z"
+                date_to = parser.parse(date_to, default=DEFAULT).isoformat() + "Z"
             except Exception:
                 print("The provided end date was not recognized")
-                parsed_to = ""
-        super().temporal(parsed_from, parsed_to, exclude_boundary)
+                date_to = ""
+
+        super().temporal(date_from, date_to, exclude_boundary)
         return self
 
 
@@ -614,8 +619,8 @@ class DataGranules(GranuleQuery):
 
     def temporal(
         self,
-        date_from: Optional[str] = None,
-        date_to: Optional[str] = None,
+        date_from: Optional[Union[str, dt.datetime]] = None,
+        date_to: Optional[Union[str, dt.datetime]] = None,
         exclude_boundary: bool = False,
     ) -> Type[GranuleQuery]:
         """Filter by an open or closed date range.
@@ -628,19 +633,21 @@ class DataGranules(GranuleQuery):
             exclude_boundary (Boolean): whether or not to exclude the date_from/to in the matched range
         """
         DEFAULT = dt.datetime(1979, 1, 1)
-        if date_from is not None:
+        if date_from is not None and not isinstance(date_from, dt.datetime):
             try:
-                parsed_from = parser.parse(date_from, default=DEFAULT).isoformat() + "Z"
+                date_from = parser.parse(date_from, default=DEFAULT).isoformat() + "Z"
             except Exception:
                 print("The provided start date was not recognized")
-                parsed_from = ""
-        if date_to is not None:
+                date_from = ""
+
+        if date_to is not None and not isinstance(date_to, dt.datetime):
             try:
-                parsed_to = parser.parse(date_to, default=DEFAULT).isoformat() + "Z"
+                date_to = parser.parse(date_to, default=DEFAULT).isoformat() + "Z"
             except Exception:
                 print("The provided end date was not recognized")
-                parsed_to = ""
-        super().temporal(parsed_from, parsed_to, exclude_boundary)
+                date_to = ""
+
+        super().temporal(date_from, date_to, exclude_boundary)
         return self
 
     def version(self, version: str = "") -> Type[GranuleQuery]:

--- a/tests/unit/test_collection_queries.py
+++ b/tests/unit/test_collection_queries.py
@@ -1,14 +1,18 @@
 # package imports
 import datetime as dt
+
 import pytest
 from earthaccess.search import DataCollections
-
 
 valid_single_dates = [
     ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T00:00:00Z"),
     ("2021-02-01", "", "2021-02-01T00:00:00Z,"),
     ("1999-02-01 06:00", "2009-01-01", "1999-02-01T06:00:00Z,2009-01-01T00:00:00Z"),
-    (dt.datetime(2021, 2, 1), dt.datetime(2021, 2, 2), "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z")
+    (
+        dt.datetime(2021, 2, 1),
+        dt.datetime(2021, 2, 2),
+        "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z",
+    ),
 ]
 
 invalid_single_dates = [
@@ -16,6 +20,7 @@ invalid_single_dates = [
     ("2021w1", "", None),
     ("2999-02-01", "2009-01-01", None),
 ]
+
 
 def test_query_can_find_cloud_provider():
     query = DataCollections().daac("PODAAC").cloud_hosted(True)

--- a/tests/unit/test_collection_queries.py
+++ b/tests/unit/test_collection_queries.py
@@ -1,6 +1,21 @@
 # package imports
+import datetime as dt
+import pytest
 from earthaccess.search import DataCollections
 
+
+valid_single_dates = [
+    ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T00:00:00Z"),
+    ("2021-02-01", "", "2021-02-01T00:00:00Z,"),
+    ("1999-02-01 06:00", "2009-01-01", "1999-02-01T06:00:00Z,2009-01-01T00:00:00Z"),
+    (dt.datetime(2021, 2, 1), dt.datetime(2021, 2, 2), "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z")
+]
+
+invalid_single_dates = [
+    ("2001-12-45", "2001-12-21", None),
+    ("2021w1", "", None),
+    ("2999-02-01", "2009-01-01", None),
+]
 
 def test_query_can_find_cloud_provider():
     query = DataCollections().daac("PODAAC").cloud_hosted(True)
@@ -18,3 +33,19 @@ def test_querybuilder_can_handle_doi():
     assert query.params["doi"] == doi
     query = DataCollections().cloud_hosted(True).daac("PODAAC").doi(doi)
     assert query.params["doi"] == doi
+
+
+@pytest.mark.parametrize("start,end,expected", valid_single_dates)
+def test_query_can_parse_single_dates(start, end, expected):
+    query = DataCollections().temporal(start, end)
+    assert query.params["temporal"][0] == expected
+
+
+@pytest.mark.parametrize("start,end,expected", invalid_single_dates)
+def test_query_can_handle_invalid_dates(start, end, expected):
+    query = DataCollections()
+    try:
+        query = query.temporal(start, end)
+    except Exception as e:
+        assert isinstance(e, ValueError)
+        assert "temporal" not in query.params

--- a/tests/unit/test_granule_queries.py
+++ b/tests/unit/test_granule_queries.py
@@ -1,4 +1,5 @@
 # package imports
+import datetime as dt
 import pytest
 from earthaccess.search import DataGranules
 
@@ -6,6 +7,7 @@ valid_single_dates = [
     ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T00:00:00Z"),
     ("2021-02-01", "", "2021-02-01T00:00:00Z,"),
     ("1999-02-01 06:00", "2009-01-01", "1999-02-01T06:00:00Z,2009-01-01T00:00:00Z"),
+    (dt.datetime(2021, 2, 1), dt.datetime(2021, 2, 2), "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z")
 ]
 
 invalid_single_dates = [

--- a/tests/unit/test_granule_queries.py
+++ b/tests/unit/test_granule_queries.py
@@ -1,5 +1,6 @@
 # package imports
 import datetime as dt
+
 import pytest
 from earthaccess.search import DataGranules
 
@@ -7,7 +8,11 @@ valid_single_dates = [
     ("2001-12-12", "2001-12-21", "2001-12-12T00:00:00Z,2001-12-21T00:00:00Z"),
     ("2021-02-01", "", "2021-02-01T00:00:00Z,"),
     ("1999-02-01 06:00", "2009-01-01", "1999-02-01T06:00:00Z,2009-01-01T00:00:00Z"),
-    (dt.datetime(2021, 2, 1), dt.datetime(2021, 2, 2), "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z")
+    (
+        dt.datetime(2021, 2, 1),
+        dt.datetime(2021, 2, 2),
+        "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z",
+    ),
 ]
 
 invalid_single_dates = [


### PR DESCRIPTION
in the `DataGranules` docstring it's written that we can pass datetime object but this wasn't true (or at least it was giving me `not recognized`) 



<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--451.org.readthedocs.build/en/451/

<!-- readthedocs-preview earthaccess end -->