### PR TITLE
improve ISO 8601 parsing for temporal filter

### DIFF
--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -19,7 +19,7 @@ def _normalize_datetime(raw: None | str | dt.date | dt.datetime) -> None | dt.da
     # add flexibility, inclusive of the presence or absence of timezone information
     if isinstance(raw, str):
         normalized = dateutil.parser.parse(raw)
-    elif not isinstance(raw, dt.datetime):
+    elif isinstance(raw, dt.date) and not isinstance(raw, dt.datetime):
         normalized = dt.datetime.combine(raw, dt.time())
     else:
         normalized = raw

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -29,7 +29,7 @@ def _normalize_datetime(raw: None | str | dt.date | dt.datetime) -> None | dt.da
         tz = normalized.tzinfo
     except AttributeError:
         raise TypeError(
-            f"Dates must be date, datetime or str, not {dt.__class__.__name__}."
+            f"Dates must be date, datetime or str, not {raw.__class__.__name__}."
         )
     if tz:
         normalized = normalized.astimezone(dt.timezone.utc)

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -342,8 +342,8 @@ class DataCollections(CollectionQuery):
 
     def temporal(
         self,
-        date_from: Optional[Union[str, dt.date, dt.datetime]] = None,
-        date_to: Optional[Union[str, dt.date, dt.datetime]] = None,
+        date_from: Optional[Union[str, dt.date]] = None,
+        date_to: Optional[Union[str, dt.date]] = None,
         exclude_boundary: bool = False,
     ) -> Type[CollectionQuery]:
         """Filter by an open or closed date range. Dates can be provided as datetime objects
@@ -697,8 +697,8 @@ class DataGranules(GranuleQuery):
 
     def temporal(
         self,
-        date_from: Optional[Union[str, dt.date, dt.datetime]] = None,
-        date_to: Optional[Union[str, dt.date, dt.datetime]] = None,
+        date_from: Optional[Union[str, dt.date]] = None,
+        date_to: Optional[Union[str, dt.date]] = None,
         exclude_boundary: bool = False,
     ) -> Type[GranuleQuery]:
         """Filter by an open or closed date range. Dates can be provided as datetime objects

--- a/tests/unit/test_granule_queries.py
+++ b/tests/unit/test_granule_queries.py
@@ -13,12 +13,14 @@ valid_single_dates = [
         dt.datetime(2021, 2, 2),
         "2021-02-01T00:00:00Z,2021-02-02T00:00:00Z",
     ),
+    ("1999-02-01 06:00:00Z", "2009-01-01", "1999-02-01T06:00:00Z,2009-01-01T00:00:00Z"),
 ]
 
 invalid_single_dates = [
-    ("2001-12-45", "2001-12-21", None),
-    ("2021w1", "", None),
-    ("2999-02-01", "2009-01-01", None),
+    ("2001-12-45", "2001-12-21", ValueError),
+    ("2021w1", "", ValueError),
+    ("2999-02-01", "2009-01-01", ValueError),
+    (123, "2009-01-01", TypeError),
 ]
 
 
@@ -35,14 +37,12 @@ def test_query_can_parse_single_dates(start, end, expected):
     assert granules.params["temporal"][0] == expected
 
 
-@pytest.mark.parametrize("start,end,expected", invalid_single_dates)
-def test_query_can_handle_invalid_dates(start, end, expected):
+@pytest.mark.parametrize("start,end,exception", invalid_single_dates)
+def test_query_can_handle_invalid_dates(start, end, exception):
     granules = DataGranules().short_name("MODIS")
-    try:
+    with pytest.raises(exception):
         granules = granules.temporal(start, end)
-    except Exception as e:
-        assert isinstance(e, ValueError)
-        assert "temporal" not in granules.params
+    assert "temporal" not in granules.params
 
 
 @pytest.mark.parametrize("bbox,expected", bbox_queries)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,83 @@
+from datetime import date, datetime, time, timedelta, timezone
+
+import pytest
+from dateutil.parser import ParserError
+from earthaccess import search
+
+
+def test__normalize_datetime():
+    normalized = search._normalize_datetime("")
+    assert normalized is None
+
+    normalized = search._normalize_datetime(None)
+    assert normalized is None
+
+    raw = "foobar"
+    with pytest.raises(ParserError, match="Unknown string format: foobar"):
+        _ = search._normalize_datetime(raw)
+
+    raw = "2024"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    raw = "2023-02"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2023, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    raw = "20210203"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2021, 2, 3, 0, 0, 0, tzinfo=timezone.utc)
+
+    raw = "20240203T12"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+    raw = "20240203T12:06"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 12, 6, 0, tzinfo=timezone.utc)
+
+    raw = "20240203T10:08:54"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
+
+    raw = "20240203T10:08:54Z"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
+
+    raw = "20240203T10:08:54+00:00"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
+
+    raw = "20240203T10:08:54-09:00"
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(2024, 2, 3, 19, 8, 54, tzinfo=timezone.utc)
+
+    raw = date(1985, 10, 19)
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 0, 0, 0, tzinfo=timezone.utc)
+
+    raw = datetime(1985, 10, 19)
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 0, 0, 0, tzinfo=timezone.utc)
+
+    raw = datetime(1985, 10, 19, 12)
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    raw = datetime(1985, 10, 19, 12, 24)
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 12, 24, 0, tzinfo=timezone.utc)
+
+    raw = datetime(1985, 10, 19, 12, tzinfo=timezone.utc)
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    raw = datetime(1985, 10, 19, 12, tzinfo=timezone(timedelta(hours=-9)))
+    normalized = search._normalize_datetime(raw)
+    assert normalized == datetime(1985, 10, 19, 21, 0, 0, tzinfo=timezone.utc)
+
+    raw = time(12, 0)
+    with pytest.raises(
+        TypeError, match="Dates must be date, datetime, or str objects, not"
+    ):
+        _ = search._normalize_datetime(raw)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -3,81 +3,46 @@ from datetime import date, datetime, time, timedelta, timezone
 import pytest
 from dateutil.parser import ParserError
 from earthaccess import search
+from numpy import datetime64
+from pandas import Timestamp
+
+handled_dates = [
+    ("", None),
+    (None, None),
+    ("2024", "2024-01-01T00:00:00Z"),
+    ("2024-02", "2024-02-01T00:00:00Z"),
+    ("2024-02-03T10", "2024-02-03T10:00:00Z"),
+    ("2024-02-03T10:08:54", "2024-02-03T10:08:54Z"),
+    ("2024-02-03T10:08:54Z", "2024-02-03T10:08:54Z"),
+    ("2024-02-03T10:08:54+00:00", "2024-02-03T10:08:54Z"),
+    ("2024-02-03T10:08:54-09:00", "2024-02-03T19:08:54Z"),
+    (date(1985, 10, 19), "1985-10-19T00:00:00Z"),
+    (datetime(1985, 10, 19, 12), "1985-10-19T12:00:00Z"),
+    (datetime(1985, 10, 19, 12, 24), "1985-10-19T12:24:00Z"),
+    (datetime(1985, 10, 19, 12, 24, tzinfo=timezone.utc), "1985-10-19T12:24:00Z"),
+    (
+        datetime(1985, 10, 19, 12, 24, tzinfo=timezone(timedelta(hours=-9))),
+        "1985-10-19T21:24:00Z",
+    ),
+    (Timestamp("1985-10-19"), "1985-10-19T00:00:00Z"),
+    ("foobar", ParserError("Unknown string format: foobar")),
+    (time(0, 0), TypeError("Dates must be a date object or str, not time.")),
+    (
+        datetime64(0, "ns"),
+        TypeError("Dates must be a date object or str, not datetime64."),
+    ),
+    (Timestamp(""), ValueError("Provided date NaT is not valid.")),
+]
 
 
-def test__normalize_datetime():
-    normalized = search._normalize_datetime("")
-    assert normalized is None
-
-    normalized = search._normalize_datetime(None)
-    assert normalized is None
-
-    raw = "foobar"
-    with pytest.raises(ParserError, match="Unknown string format: foobar"):
-        _ = search._normalize_datetime(raw)
-
-    raw = "2024"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-
-    raw = "2023-02"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2023, 2, 1, 0, 0, 0, tzinfo=timezone.utc)
-
-    raw = "20210203"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2021, 2, 3, 0, 0, 0, tzinfo=timezone.utc)
-
-    raw = "20240203T12"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 12, 0, 0, tzinfo=timezone.utc)
-
-    raw = "20240203T12:06"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 12, 6, 0, tzinfo=timezone.utc)
-
-    raw = "20240203T10:08:54"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
-
-    raw = "20240203T10:08:54Z"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
-
-    raw = "20240203T10:08:54+00:00"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 10, 8, 54, tzinfo=timezone.utc)
-
-    raw = "20240203T10:08:54-09:00"
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(2024, 2, 3, 19, 8, 54, tzinfo=timezone.utc)
-
-    raw = date(1985, 10, 19)
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 0, 0, 0, tzinfo=timezone.utc)
-
-    raw = datetime(1985, 10, 19)
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 0, 0, 0, tzinfo=timezone.utc)
-
-    raw = datetime(1985, 10, 19, 12)
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 12, 0, 0, tzinfo=timezone.utc)
-
-    raw = datetime(1985, 10, 19, 12, 24)
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 12, 24, 0, tzinfo=timezone.utc)
-
-    raw = datetime(1985, 10, 19, 12, tzinfo=timezone.utc)
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 12, 0, 0, tzinfo=timezone.utc)
-
-    raw = datetime(1985, 10, 19, 12, tzinfo=timezone(timedelta(hours=-9)))
-    normalized = search._normalize_datetime(raw)
-    assert normalized == datetime(1985, 10, 19, 21, 0, 0, tzinfo=timezone.utc)
-
-    raw = time(12, 0)
-    with pytest.raises(
-        TypeError, match="Dates must be date, datetime, or str objects, not"
-    ):
-        _ = search._normalize_datetime(raw)
+@pytest.mark.parametrize("raw,expected", handled_dates)
+def test__normalize_datetime(raw, expected):
+    if isinstance(expected, Exception):
+        with pytest.raises(type(expected), match=str(expected)):
+            _ = search._normalize_datetime(raw)
+    elif expected:
+        assert (
+            search._normalize_datetime(raw).strftime("%Y-%m-%dT%H:%M:%SZ") == expected
+        )
+    else:
+        assert search._normalize_datetime(raw) is None


### PR DESCRIPTION
Fixes #330.

As suggested by @jhkennedy, earthaccess will now pass a `datetime` object (or `None`) to `cmr`, essentially replacing the basic string parsing that `cmr` does (using `datetime.strptime`) with flexible and timezone aware parsing by `dateutil.parser`.

The change created the opportunity to create a new suite of tests for possible user inputs, that includes checking exceptions.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--486.org.readthedocs.build/en/486/

<!-- readthedocs-preview earthaccess end -->