### PR TITLE
Add dodsrc and urs cookies files when creating netrc

### DIFF
--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -379,7 +379,7 @@ class Auth(object):
 
         # Create and write to .dodsrc file
         dodsrc_file = Path.home() / ".dodsrc"
-        dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_file}"
+        dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_path}"
         dodsrc_file.write_text(dodsrc_contents)
 
         if platform.system() == "Windows":

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -388,7 +388,7 @@ class Auth(object):
             local_dodsrc_path = Path.cwd() / dodsrc_path.name
             if not local_dodsrc_path.exists():
                 shutil.copy2(dodsrc_path, local_dodsrc_path)
-                
+
         return True
 
     def _get_cloud_auth_url(

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -383,12 +383,12 @@ class Auth(object):
                 f"HTTP.COOKIEJAR={urs_cookies_path}\nHTTP.NETRC={netrc_path}"
             )
             dodsrc_path.write_text(dodsrc_contents)
-       
+
         if platform.system() == "Windows":
             local_dodsrc_path = Path.cwd() / dodsrc_path.name
             if not local_dodsrc_path.exists():
                 shutil.copy2(dodsrc_path, local_dodsrc_path)
-            
+                
         return True
 
     def _get_cloud_auth_url(

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -372,7 +372,6 @@ class Auth(object):
         my_netrc = Netrc(str(netrc_path))
         my_netrc["urs.earthdata.nasa.gov"] = {"login": username, "password": password}
         my_netrc.save()
-        netrc_file = Path.home() / ".netrc"
 
         # Create and write .urs_cookies file
         urs_cookies_file = Path.home() / ".urs_cookies"

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -379,7 +379,7 @@ class Auth(object):
         # Create and write to .dodsrc file
         dodsrc_path = Path.home() / ".dodsrc"
         if not dodsrc_path.exists():
-            dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_path}"
+            dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_path}\nHTTP.NETRC={netrc_path}"
             dodsrc_path.write_text(dodsrc_contents)
        
         

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -2,6 +2,8 @@ import getpass
 import importlib.metadata
 import logging
 import os
+import platform
+import shutil
 from netrc import NetrcParseError
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -370,6 +372,20 @@ class Auth(object):
         my_netrc = Netrc(str(netrc_path))
         my_netrc["urs.earthdata.nasa.gov"] = {"login": username, "password": password}
         my_netrc.save()
+        netrc_file = Path.home() / '.netrc'
+
+        # Create and write .urs_cookies file
+        urs_cookies_file = Path.home() / '.urs_cookies'
+        urs_cookies_file.write_text('')
+
+        # Create and write to .dodsrc file
+        dodsrc_file = Path.home() / '.dodsrc'
+        dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_file}"
+        dodsrc_file.write_text(dodsrc_contents)
+
+        if platform.system() == "Windows":
+            shutil.copy2(dodsrc_file, Path.cwd())
+
         return True
 
     def _get_cloud_auth_url(

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -373,7 +373,7 @@ class Auth(object):
         my_netrc["urs.earthdata.nasa.gov"] = {"login": username, "password": password}
         my_netrc.save()
         urs_cookies_path = Path.home() / ".urs_cookies"
-        if not usr_cookies_path.exists():
+        if not urs_cookies_path.exists():
             urs_cookies_path.write_text("")
 
         # Create and write to .dodsrc file
@@ -383,7 +383,7 @@ class Auth(object):
             dodsrc_path.write_text(dodsrc_contents)
        
         
-       if platform.system() == "Windows":
+        if platform.system() == "Windows":
             local_dodsrc_path = Path.cwd() / dodsrc_path.name
             if not local_dodsrc_path.exists():
                 shutil.copy2(dodsrc_path, local_dodsrc_path)

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -372,18 +372,22 @@ class Auth(object):
         my_netrc = Netrc(str(netrc_path))
         my_netrc["urs.earthdata.nasa.gov"] = {"login": username, "password": password}
         my_netrc.save()
-
-        # Create and write .urs_cookies file
-        urs_cookies_file = Path.home() / ".urs_cookies"
-        urs_cookies_file.write_text("")
+        urs_cookies_path = Path.home() / ".urs_cookies"
+        if not usr_cookies_path.exists():
+            urs_cookies_path.write_text("")
 
         # Create and write to .dodsrc file
-        dodsrc_file = Path.home() / ".dodsrc"
-        dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_path}"
-        dodsrc_file.write_text(dodsrc_contents)
-
-        if platform.system() == "Windows":
-            shutil.copy2(dodsrc_file, Path.cwd())
+        dodsrc_path = Path.home() / ".dodsrc"
+        if not dodsrc_path.exists():
+            dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_path}"
+            dodsrc_path.write_text(dodsrc_contents)
+       
+        
+       if platform.system() == "Windows":
+            local_dodsrc_path = Path.cwd() / dodsrc_path.name
+            if not local_dodsrc_path.exists():
+                shutil.copy2(dodsrc_path, local_dodsrc_path)
+            
 
         return True
 

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -372,14 +372,14 @@ class Auth(object):
         my_netrc = Netrc(str(netrc_path))
         my_netrc["urs.earthdata.nasa.gov"] = {"login": username, "password": password}
         my_netrc.save()
-        netrc_file = Path.home() / '.netrc'
+        netrc_file = Path.home() / ".netrc"
 
         # Create and write .urs_cookies file
-        urs_cookies_file = Path.home() / '.urs_cookies'
-        urs_cookies_file.write_text('')
+        urs_cookies_file = Path.home() / ".urs_cookies"
+        urs_cookies_file.write_text("")
 
         # Create and write to .dodsrc file
-        dodsrc_file = Path.home() / '.dodsrc'
+        dodsrc_file = Path.home() / ".dodsrc"
         dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_file}\nHTTP.NETRC={netrc_file}"
         dodsrc_file.write_text(dodsrc_contents)
 

--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -379,16 +379,16 @@ class Auth(object):
         # Create and write to .dodsrc file
         dodsrc_path = Path.home() / ".dodsrc"
         if not dodsrc_path.exists():
-            dodsrc_contents = f"HTTP.COOKIEJAR={urs_cookies_path}\nHTTP.NETRC={netrc_path}"
+            dodsrc_contents = (
+                f"HTTP.COOKIEJAR={urs_cookies_path}\nHTTP.NETRC={netrc_path}"
+            )
             dodsrc_path.write_text(dodsrc_contents)
        
-        
         if platform.system() == "Windows":
             local_dodsrc_path = Path.cwd() / dodsrc_path.name
             if not local_dodsrc_path.exists():
                 shutil.copy2(dodsrc_path, local_dodsrc_path)
             
-
         return True
 
     def _get_cloud_auth_url(


### PR DESCRIPTION
This PR includes code that will also create a .urs_cookies and .dodsrc files when users persist their credentials to a .netrc file, and will copy the .dodsrc file based on the user operating system. It is based on code from this how-to, but adapted here to use pathlib: https://disc.gsfc.nasa.gov/information/howto?keywords=prerequisite&title=How%20to%20Generate%20Earthdata%20Prerequisite%20Files

I have tested this with poetry on both Linux/Windows, and it works great!

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--492.org.readthedocs.build/en/492/

<!-- readthedocs-preview earthaccess end -->