### PR TITLE
Remove deprecated NISAR URL from auth.py

### DIFF
--- a/earthaccess/auth.py
+++ b/earthaccess/auth.py
@@ -31,7 +31,6 @@ class SessionWithHeaderRedirection(requests.Session):
         "urs.earthdata.nasa.gov",
         "cumulus.asf.alaska.edu",
         "sentinel1.asf.alaska.edu",
-        "nisar.asf.alaska.edu",
         "datapool.asf.alaska.edu",
     ]
 


### PR DESCRIPTION
By request of NASA, ASF has moved the NISAR distribution endpoint to <https://nisar.asf.earthdatacloud.nasa.gov/> and killed the endpoint listed in `auth.py`. 

Word on the street is that when NISAR collections do show up in CMR, they will have URLs pointing directly to this distribution endpoint instead of obscured by `datapool.asf.alasak.edu`, so we shouldn't need to list it here. 

If we do end up needing to list it here, I'd rather circle back once a public collection is in CMR.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--495.org.readthedocs.build/en/495/

<!-- readthedocs-preview earthaccess end -->