### PR TITLE
Fix erroneous workflow cancellation

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,7 +14,7 @@ on:
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: integration-tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-mindeps.yml
+++ b/.github/workflows/test-mindeps.yml
@@ -8,7 +8,7 @@ on:
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
 concurrency:
-  group: ${{ github.ref }}
+  group: test-mindeps-${{ github.ref }}
   cancel-in-progress: true
 
 # Required shell entrypoint to have properly activated conda environments


### PR DESCRIPTION
The concurrency groups for both integration-tests and test-mindeps were named the same, creating a race condition such that whichever workflow was started first would be cancelled by the start of the second workflow. This fix gives them distinct group names to avoid erroneously cancelling one or the other.

Fixes #503

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--505.org.readthedocs.build/en/505/

<!-- readthedocs-preview earthaccess end -->