### PR TITLE
Add content about hack days to our docs

### DIFF
--- a/docs/welcome/work_with_us.md
+++ b/docs/welcome/work_with_us.md
@@ -1,1 +1,0 @@
-# Work With Us

--- a/docs/work-with-us.md
+++ b/docs/work-with-us.md
@@ -2,11 +2,11 @@
 
 ## Bi-weekly (alternating weeks) _earthaccess_ hack days
 
-???+ info
+???+ info "How to get invited"
 
-  For an invitation to our recurring hack day meeting, please visit our
-  [announcement thread on GitHub Discussions](https://github.com/nsidc/earthaccess/discussions/440#)
-  and make a comment to request a calendar invitation and Zoom link.
+    For an invitation to our recurring hack day meeting, please visit our
+    [announcement thread on GitHub Discussions](https://github.com/nsidc/earthaccess/discussions/440#)
+    and make a comment to request a calendar invitation and Zoom link.
 
 
 Hack days...

--- a/docs/work-with-us.md
+++ b/docs/work-with-us.md
@@ -1,0 +1,21 @@
+# How to collaborate with the _earthaccess_ team
+
+## Bi-weekly (alternating weeks) _earthaccess_ hack days
+
+???+ info
+
+  For an invitation to our recurring hack day meeting, please visit our
+  [announcement thread on GitHub Discussions](https://github.com/nsidc/earthaccess/discussions/440#)
+  and make a comment to request a calendar invitation and Zoom link.
+
+
+Hack days...
+
+* Occur on alternating Tuesdays at 11AM - 1PM Mountain Time.
+* Are self-determining; you can work on what sounds fun to you!
+* Will support you; _earthaccess_ developers, maintainers, and community managers will
+  be present on the call.
+* Include live demos on request!
+
+For a glimpse in to the work we do on a typical hack day, please visit our
+[hack day share-out space in GitHub Discussions](https://github.com/nsidc/earthaccess/discussions/categories/hack-days)!

--- a/docs/work-with-us.md
+++ b/docs/work-with-us.md
@@ -13,7 +13,7 @@ Hack days...
 
 * Occur on alternating Tuesdays at 11AM - 1PM Mountain Time.
 * Are self-determining; you can work on what sounds fun to you!
-* Will support you; _earthaccess_ developers, maintainers, and community managers will
+* Are supportive; _earthaccess_ developers, maintainers, and community managers will
   be present on the call.
 * Include live demos on request!
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,15 +50,12 @@ nav:
       - "What is earthaccess?": "index.md"
       - "Quick Start": "welcome/quick_start.md"
       - "Work With Us": "work-with-us.md"
+      - "Resources": "resources.md"
   - User Guide:
       - "Overview": "user_guide/overview.md"
       - "Authentication": "user_guide/authenticate.md"
       - "Search": "user_guide/search.md"
       - "Access": "user_guide/access.md"
-  - OVERVIEW:
-      - "Readme": "index.md"
-      - "Getting started": "tutorials/getting-started.ipynb"
-      - "Resources": "resources.md"
   - HOW-TO:
       - "Authenticate with Earthdata Login": "howto/authenticate.md"
       - "Search NASA datasets using filters": "howto/search-collections.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,12 +49,16 @@ nav:
   - Welcome:
       - "What is earthaccess?": "index.md"
       - "Quick Start": "welcome/quick_start.md"
-      - "Work With Us": "welcome/work_with_us.md" 
+      - "Work With Us": "work-with-us.md"
   - User Guide:
       - "Overview": "user_guide/overview.md"
       - "Authentication": "user_guide/authenticate.md"
       - "Search": "user_guide/search.md"
       - "Access": "user_guide/access.md"
+  - OVERVIEW:
+      - "Readme": "index.md"
+      - "Getting started": "tutorials/getting-started.ipynb"
+      - "Resources": "resources.md"
   - HOW-TO:
       - "Authenticate with Earthdata Login": "howto/authenticate.md"
       - "Search NASA datasets using filters": "howto/search-collections.md"


### PR DESCRIPTION
Right now, our announcement thread is the best place to link folks to learn about hack days. A permanent page in our docs is probably more useful! As we change our ways of collaborating with the public, e.g. transitioning to office hours?, we could update this page.