### PR TITLE
Split the README into a GitHub README and separate Mkdocs doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome
+# _earthaccess_
 
 <p align="center">
 <img alt="earthaccess, a python library to search, download or stream NASA Earth science data with just a few lines of code" src="https://user-images.githubusercontent.com/717735/205517116-7a5d0f41-7acc-441e-94ba-2e541bfb7fc8.png" width="70%" align="center" />
@@ -33,25 +33,16 @@
 </p>
 
 
-## What is `earthaccess`?
-
 `earthaccess` is a python library to **search for**, and **download** or **stream** NASA Earth science data with just a few lines of code.
 
-Open science only reaches its full potential if we have easy-to-use workflows that facilitate research in an inclusive, efficient and reproducible way. Unfortunately —as it stands today— scientists and students alike face a steep learning curve adapting to systems that have grown too complex and end up spending more time on the technicalities of the tools, cloud and NASA APIs than focusing on their important science.
-
-During several workshops organized by [NASA Openscapes](https://nasa-openscapes.github.io/events.html), the need to provide easy-to-use tools to our users became evident. Open science is a collaborative effort; it involves people from different technical backgrounds, and the data analysis to solve the pressing problems we face cannot be limited by the complexity of the underlying systems. Therefore, providing easy access to NASA Earthdata regardless of the data storage location (hosted within or outside of the cloud) is the main motivation behind this Python library.
-
-The library is an open source community effort under an [MIT license](LICENSE.txt).  We welcome contributions to improve `earthaccess`.  Please see the [Contributing Guide](CONTRIBUTING.md) to learn how to get involved.
-
-***earthaccess*** handles authentication with [NASA's Earthdata Login (EDL)](https://urs.earthdata.nasa.gov), search using NASA's [CMR](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html) and access through [`fsspec`](https://github.com/fsspec/filesystem_spec).
+Visit [our documentation](https://earthaccess.readthedocs.io/en/latest) to learn more!
 
 Try it in your browser without installing anything! [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nsidc/earthaccess/main)
 
 
-
 ## How to Get Started with `earthaccess`
 
-Go to the [Quick Start](quick-start.md) to learn how to install and see a simple example of using `earthaccess`.
+Visit [our quick start guide](https://earthaccess.readthedocs.io/en/latest/quick-start.html) to learn how to install and see a simple example of using `earthaccess`.
 
 
 ## Compatibility
@@ -61,10 +52,10 @@ Only **Python 3.8+** is supported.
 
 ## How to Contribute to `earthaccess`
 
-If you want to find out how to contribute to `earthaccess` checkout the [Contributing Guide](CONTRIBUTING.md).
+If you want to find out how to contribute to `earthaccess` checkout the [Contributing Guide](https://earthaccess.readthedocs.io/en/latest/contributing/).
 
 
-## Contributors
+### Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=nsidc/earthaccess)](https://github.com/nsidc/earthaccess/graphs/contributors)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,11 @@
-../README.md
+# What is `earthaccess`?
+
+`earthaccess` is a python library to **search for**, and **download** or **stream** NASA Earth science data with just a few lines of code.
+
+Open science only reaches its full potential if we have easy-to-use workflows that facilitate research in an inclusive, efficient and reproducible way. Unfortunately —as it stands today— scientists and students alike face a steep learning curve adapting to systems that have grown too complex and end up spending more time on the technicalities of the tools, cloud and NASA APIs than focusing on their important science.
+
+During several workshops organized by [NASA Openscapes](https://nasa-openscapes.github.io/events.html), the need to provide easy-to-use tools to our users became evident. Open science is a collaborative effort; it involves people from different technical backgrounds, and the data analysis to solve the pressing problems we face cannot be limited by the complexity of the underlying systems. Therefore, providing easy access to NASA Earthdata regardless of the data storage location (hosted within or outside of the cloud) is the main motivation behind this Python library.
+
+The library is an open source community effort under an [MIT license](LICENSE.txt).  We welcome contributions to improve `earthaccess`.  Please see the [Contributing Guide](contributing/index.md) to learn how to get involved.
+
+***earthaccess*** handles authentication with [NASA's Earthdata Login (EDL)](https://urs.earthdata.nasa.gov), search using NASA's [CMR](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html) and access through [`fsspec`](https://github.com/fsspec/filesystem_spec).


### PR DESCRIPTION
Supersedes #534 .

The problem is that GitHub and Mkdocs use different syntax and have a different root directory, so symlinking files from the root directory isn't working as we expect it to work.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--541.org.readthedocs.build/en/541/

<!-- readthedocs-preview earthaccess end -->