### PR TITLE
Fix broken quick start link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Try it in your browser without installing anything! [![Binder](https://mybinder.
 
 ## How to Get Started with `earthaccess`
 
-Visit [our quick start guide](https://earthaccess.readthedocs.io/en/latest/quick-start.html) to learn how to install and see a simple example of using `earthaccess`.
+Visit [our quick start guide](https://earthaccess.readthedocs.io/en/latest/quick-start/) to learn how to install and see a simple example of using `earthaccess`.
 
 
 ## Compatibility


### PR DESCRIPTION
https://earthaccess.readthedocs.io/en/latest/quick-start/  had `.html` appended - I just updated with the correct link.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--560.org.readthedocs.build/en/560/

<!-- readthedocs-preview earthaccess end -->