### PR TITLE
Use yamlfmt instead of prettier to format YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,11 @@ Temporary Items
 .envrc
 
 # End of https://www.toptal.com/developers/gitignore/api/direnv
+
+# Created by https://www.toptal.com/developers/gitignore/api/asdf
+# Edit at https://www.toptal.com/developers/gitignore?templates=asdf
+
+### asdf ###
+/.tool-versions
+
+# End of https://www.toptal.com/developers/gitignore/api/asdf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,10 @@ repos:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]
       - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.12.1
     hooks:
-      - id: prettier
+      - id: yamlfmt
         types_or: [yaml]
         exclude: ".*/vcr_cassettes/.*\\.yaml"
 

--- a/.yamlfmt.yml
+++ b/.yamlfmt.yml
@@ -1,0 +1,2 @@
+formatter:
+  retain_line_breaks_single: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,31 @@
 # Changelog
 
 ## [Unreleased]
+
 * Changes
-  * Removed the `get_user_profile` method and the `email_address` and `profile` attributes from the `Auth` class ([#421](https://github.com/nsidc/earthaccess/issues/421))
-* Bug fixes:
-    * fixed 483 by extracting a common CMR query method for collections and granules using SearchAfter header
-    * Added VCR support for verifying the API call to CMR and the parsing of returned results without relying on CMR availability post development
+
+  * [#421](https://github.com/nsidc/earthaccess/issues/421): Removed the
+    `get_user_profile` method and the `email_address` and `profile` attributes
+    from the `Auth` class.  Calling the EDL API to get user profile information
+    is not intended for library access and is not necessary for this library's
+    intended use cases.
+  * [#555](https://github.com/nsidc/earthaccess/issues/555): YAML formatting is
+    now performed with `yamlfmt` instead of `prettier`.
+
+* Enhancements
+
+  * [#483](https://github.com/nsidc/earthaccess/issues/483): Now using
+    [Search After](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#search-after)
+    for collection and granule searches to support deep-paging through large
+    result sets.
+  * [#508](https://github.com/nsidc/earthaccess/issues/508): Corrected and
+    enhanced static type hints for functions and methods that make CMR queries
+    or handle CMR query results.
+  * [#421](https://github.com/nsidc/earthaccess/issues/421): Enabled queries to
+    Earthdata User Acceptance Testing (UAT) system for authenticated accounts.
   * [#562](https://github.com/nsidc/earthaccess/issues/562): The destination
      path is now created prior to direct S3 downloads, if it doesn't already
      exist.
-
-* Enhancements:
-  * Corrected and enhanced static type hints for functions and methods that make
-    CMR queries or handle CMR query results ([#508](https://github.com/nsidc/earthaccess/issues/508))
-  * Enable queries to Earthdata User Acceptance Testing (UAT) system for authenticated accounts ([#421](https://github.com/nsidc/earthaccess/issues/421))
 
 ## [v0.9.0] 2024-02-28
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,11 +76,10 @@ nav:
       - "Download data from on-prem location": "howto/onprem.md"
       - "Direct S3 access - Open/stream files in the cloud": "howto/cloud.md"
   - TUTORIALS:
-      - "Accesing remote NASA data with fsspec": "tutorials/file-access.ipynb"
+      - "Accessing remote NASA data with fsspec": "tutorials/file-access.ipynb"
       - "Search and access of restricted datasets": "tutorials/restricted-datasets.ipynb"
       - "Reproducing NASA sea level rise infographic": "tutorials/SSL.ipynb"
       - "Accessing and visualizing EMIT data with a few lines of code": "tutorials/emit-earthaccess.ipynb"
-      # - 'Distributing workloads with Dask clusters': 'tutorials/dask.ipynb'
   - USER REFERENCE:
       - API:
           - "Search and Access": "user-reference/api/api.md"


### PR DESCRIPTION
Fixes #555

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--568.org.readthedocs.build/en/568/

<!-- readthedocs-preview earthaccess end -->