### PR TITLE
remove the unreferenced `CLOUD_PROVIDERS` list

### DIFF
--- a/earthaccess/daac.py
+++ b/earthaccess/daac.py
@@ -106,18 +106,6 @@ DAACS = [
 ]
 
 
-CLOUD_PROVIDERS = [
-    "GES_DISC",
-    "LPCLOUD",
-    "NSIDC_CPRD",
-    "POCLOUD",
-    "ASF",
-    "GHRC_DAAC",
-    "ORNL_CLOUD",
-    "LAADS",
-    "LARC_CLOUD",
-]
-
 # Some testing urls behind EDL
 DAAC_TEST_URLS = [
     "https://archive.podaac.earthdata.nasa.gov/podaac-ops-cumulus-protected/JASON_CS_S6A_L2_ALT_LR_STD_OST_NRT_F/",


### PR DESCRIPTION
Closes #564.

The bug does not appear to be that "OBDAAC" is missing from `earthaccess.daac.CLOUD_PROVIDERS`. Rather, the issue seems to be that this list exists without having any function. The `CLOUD_PROVIDERS` list is not referenced in the project (according to VS Code and text search) and deleting it breaks no tests. This PR removes the cruft and does nothing else.

Please close without merging if you're aware of any purpose for this variable.

As far as adding OBDAAC goes, I think it was added correctly in #516.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--603.org.readthedocs.build/en/603/

<!-- readthedocs-preview earthaccess end -->