### PR TITLE
Improve PyPI sidebar URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [tool.poetry]
 name = "earthaccess"
 version = "0.9.0"
-homepage = "https://github.com/nsidc/earthaccess"
+repository = "https://github.com/nsidc/earthaccess"
+documentation = "https://earthaccess.readthedocs.io"
 description = "Client library for NASA Earthdata APIs"
 authors = ["earthaccess contributors"]
 maintainers = [


### PR DESCRIPTION
A colleague, and frequent `earthaccess` user, just said they did not know about https://earthaccess.readthedocs.io. Maybe adding the "documentation" URL will help this resource percolate through. Also changed "homepage" to the more specific "repository" (gets an octocat on PyPI).

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--607.org.readthedocs.build/en/607/

<!-- readthedocs-preview earthaccess end -->