### PR TITLE
the earthaccess.EarthAccessFile wrapper need not subclass anything

### DIFF
--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -25,8 +25,10 @@ from .search import DataCollections
 logger = logging.getLogger(__name__)
 
 
-class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
-    def __init__(self, f: fsspec.AbstractFileSystem, granule: DataGranule) -> None:
+class EarthAccessFile:
+    def __init__(
+        self, f: fsspec.spec.AbstractBufferedFile, granule: DataGranule
+    ) -> None:
         self.f = f
         self.granule = granule
 
@@ -42,7 +44,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
         )
 
     def __repr__(self) -> str:
-        return str(self.f)
+        return repr(self.f)
 
 
 def _open_files(


### PR DESCRIPTION
Fixes #610.

This PR removes a base class from the definition of `earthaccess.EarthAccessFile`. With inheritance, methods defined on `fsspec.spec.AbstractBufferedFilesystem` are discovered before any overrides defined on `f`.

The `earthaccess.EarthAccessFile` wrapper is handed the results of a `fsspec.filesystem().open()` call. That result is a `fsspec.spec.AbstractBufferedFile` (this PR fixes the type hint on that, btw) and stored in `f`. This wrapper's main job is to pass attribute calls off to `f`. The wrapper itself is not a file-like object; we can't make fsspec give us a custom subclass.


Would appreciate running workflows on this. Unit tests are good, but I still can't get all the integration tests working on openscapes.2i2c.cloud.

ToDo if integration tests look okay:
- [ ] add to changelog
- [ ] check for any changes needed to docs
