### PR TITLE
Key removal

### DIFF
--- a/docs/howto/edl.ipynb
+++ b/docs/howto/edl.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "a7bb1a93-6f85-40cd-93b4-ce821a03a8b5",
    "metadata": {},
    "outputs": [],
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "c0f4e286-8ce9-4cde-b3a2-631b361a0d51",
    "metadata": {},
    "outputs": [
@@ -81,7 +81,7 @@
        "'�HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00���������HUn\\x00\\x00\\x00\\x00��������\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR\\x02'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "1e5f5f7a-0643-42cb-b70c-4ac982824ff9",
    "metadata": {},
    "outputs": [],
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "fbc7bc5f-b984-4324-b095-3648a437fba2",
    "metadata": {},
    "outputs": [
@@ -122,7 +122,7 @@
        "b'\\x89HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xd7HUn\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,14 +135,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "07433a9f-f276-4d2b-9ed3-f556df2884af",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac15458d5f9e4b8aac40f2e5417b22c7",
+       "model_id": "9e8e316215154002afe0c89ccc174a04",
        "version_major": 2,
        "version_minor": 0
       },
@@ -156,7 +156,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "100cb212635146bab6548c8bf171d970",
+       "model_id": "ff1c8adf11a04dc4aa799fe45aa7460d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -170,7 +170,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3754ed8d0297407cade522b651c59ead",
+       "model_id": "77eac7c793e7416bb91196733769f3fe",
        "version_major": 2,
        "version_minor": 0
       },
@@ -185,8 +185,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.73 s, sys: 241 ms, total: 2.97 s\n",
-      "Wall time: 10.9 s\n"
+      "CPU times: user 1.37 s, sys: 207 ms, total: 1.58 s\n",
+      "Wall time: 11.8 s\n"
      ]
     },
     {
@@ -561,7 +561,7 @@
        "Data variables:\n",
        "    wavelengths       (bands) float32 1kB ...\n",
        "    fwhm              (bands) float32 1kB ...\n",
-       "    good_wavelengths  (bands) float32 1kB ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a77454ce-32d9-4909-8c2f-c3a69f1acf05' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a77454ce-32d9-4909-8c2f-c3a69f1acf05' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-3e7c8c34-32f3-4201-a03b-bdc984c1cbc2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3e7c8c34-32f3-4201-a03b-bdc984c1cbc2' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-a6f008f4-112b-4032-a4f8-71aeda7d1911' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a6f008f4-112b-4032-a4f8-71aeda7d1911' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a1e99f53-de37-49f4-801b-28a334707122' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a1e99f53-de37-49f4-801b-28a334707122' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-555eb7e3-7b9c-4e1a-aa4f-723a6321f4f8' class='xr-var-data-in' type='checkbox'><label for='data-555eb7e3-7b9c-4e1a-aa4f-723a6321f4f8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-92f72bbe-e94a-4cce-a3b1-491e689450e5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-92f72bbe-e94a-4cce-a3b1-491e689450e5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2fe6397f-1398-4e1f-b838-45a166683893' class='xr-var-data-in' type='checkbox'><label for='data-2fe6397f-1398-4e1f-b838-45a166683893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-48051428-22ff-4a40-85e7-27ff7c18a3c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-48051428-22ff-4a40-85e7-27ff7c18a3c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f4b76c8f-6015-4870-a7e7-e21a6b65eaa4' class='xr-var-data-in' type='checkbox'><label for='data-f4b76c8f-6015-4870-a7e7-e21a6b65eaa4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-dc6c043e-46f6-4544-be92-b2f94b99f0fd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-dc6c043e-46f6-4544-be92-b2f94b99f0fd' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-5dbe57d8-f873-48bb-8e68-b27e57402e7b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5dbe57d8-f873-48bb-8e68-b27e57402e7b' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "    good_wavelengths  (bands) float32 1kB ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f3191e16-f6f0-4ea6-8a65-ff2fb9b1d7a3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f3191e16-f6f0-4ea6-8a65-ff2fb9b1d7a3' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8b396b6f-7ebb-4f1b-9fa0-80ef526ccc79' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-8b396b6f-7ebb-4f1b-9fa0-80ef526ccc79' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-b01fce12-3752-4a0f-9325-d753200229fc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b01fce12-3752-4a0f-9325-d753200229fc' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-be533a94-3dc4-4afd-bf0a-0f2bb93006bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-be533a94-3dc4-4afd-bf0a-0f2bb93006bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ebcd4b7-baf8-439d-9359-a721890439d8' class='xr-var-data-in' type='checkbox'><label for='data-2ebcd4b7-baf8-439d-9359-a721890439d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ae219362-43ef-4535-8ad1-8b22613f8dba' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae219362-43ef-4535-8ad1-8b22613f8dba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85e821e2-e6a8-4ba8-afef-4807aebc3ff9' class='xr-var-data-in' type='checkbox'><label for='data-85e821e2-e6a8-4ba8-afef-4807aebc3ff9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5d2cc45b-0bcb-490a-9a68-bee2a718111d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5d2cc45b-0bcb-490a-9a68-bee2a718111d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fb3356cc-cd92-4ef7-9f35-ad87797cf084' class='xr-var-data-in' type='checkbox'><label for='data-fb3356cc-cd92-4ef7-9f35-ad87797cf084' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-72d5040f-ff26-4e3d-83ab-84d1f04c602c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-72d5040f-ff26-4e3d-83ab-84d1f04c602c' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-17e53eab-bf26-4ea5-96ad-d2a9f5490cde' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-17e53eab-bf26-4ea5-96ad-d2a9f5490cde' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 3kB\n",
@@ -573,7 +573,7 @@
        "    good_wavelengths  (bands) float32 1kB ..."
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/howto/edl.ipynb
+++ b/docs/howto/edl.ipynb
@@ -30,11 +30,17 @@
    "metadata": {},
    "source": [
     "### Data in AWS\n",
-    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs. This line is commented out for security reasons. Please copy the following line into a new code block in order to obtain your credentials. \n",
-    "\n",
-    "```\n",
-    "s3_credentials = auth.get_s3_credentials(\"NSIDC\")\n",
-    "```"
+    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs. This line is commented out for security reasons. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f1f45172-c9c3-4f25-ad7e-acf94fba8b1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#s3_credentials = auth.get_s3_credentials(\"NSIDC\")"
    ]
   },
   {
@@ -57,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "a7bb1a93-6f85-40cd-93b4-ce821a03a8b5",
    "metadata": {},
    "outputs": [],
@@ -71,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "c0f4e286-8ce9-4cde-b3a2-631b361a0d51",
    "metadata": {},
    "outputs": [
@@ -81,7 +87,7 @@
        "'�HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00���������HUn\\x00\\x00\\x00\\x00��������\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR\\x02'"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -102,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "1e5f5f7a-0643-42cb-b70c-4ac982824ff9",
    "metadata": {},
    "outputs": [],
@@ -112,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "fbc7bc5f-b984-4324-b095-3648a437fba2",
    "metadata": {},
    "outputs": [
@@ -122,7 +128,7 @@
        "b'\\x89HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xd7HUn\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR'"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,14 +141,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "07433a9f-f276-4d2b-9ed3-f556df2884af",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9e8e316215154002afe0c89ccc174a04",
+       "model_id": "c76e3afc58a84118a04144f2f08ff6bc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -156,7 +162,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ff1c8adf11a04dc4aa799fe45aa7460d",
+       "model_id": "98f4219952eb4e9bb8f60ad67f438454",
        "version_major": 2,
        "version_minor": 0
       },
@@ -170,7 +176,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "77eac7c793e7416bb91196733769f3fe",
+       "model_id": "9451a7fda27e4569968054028576999d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -185,8 +191,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.37 s, sys: 207 ms, total: 1.58 s\n",
-      "Wall time: 11.8 s\n"
+      "CPU times: user 1.4 s, sys: 179 ms, total: 1.58 s\n",
+      "Wall time: 10.5 s\n"
      ]
     },
     {
@@ -561,7 +567,7 @@
        "Data variables:\n",
        "    wavelengths       (bands) float32 1kB ...\n",
        "    fwhm              (bands) float32 1kB ...\n",
-       "    good_wavelengths  (bands) float32 1kB ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f3191e16-f6f0-4ea6-8a65-ff2fb9b1d7a3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f3191e16-f6f0-4ea6-8a65-ff2fb9b1d7a3' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-8b396b6f-7ebb-4f1b-9fa0-80ef526ccc79' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-8b396b6f-7ebb-4f1b-9fa0-80ef526ccc79' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-b01fce12-3752-4a0f-9325-d753200229fc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b01fce12-3752-4a0f-9325-d753200229fc' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-be533a94-3dc4-4afd-bf0a-0f2bb93006bb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-be533a94-3dc4-4afd-bf0a-0f2bb93006bb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2ebcd4b7-baf8-439d-9359-a721890439d8' class='xr-var-data-in' type='checkbox'><label for='data-2ebcd4b7-baf8-439d-9359-a721890439d8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ae219362-43ef-4535-8ad1-8b22613f8dba' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ae219362-43ef-4535-8ad1-8b22613f8dba' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-85e821e2-e6a8-4ba8-afef-4807aebc3ff9' class='xr-var-data-in' type='checkbox'><label for='data-85e821e2-e6a8-4ba8-afef-4807aebc3ff9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-5d2cc45b-0bcb-490a-9a68-bee2a718111d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5d2cc45b-0bcb-490a-9a68-bee2a718111d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fb3356cc-cd92-4ef7-9f35-ad87797cf084' class='xr-var-data-in' type='checkbox'><label for='data-fb3356cc-cd92-4ef7-9f35-ad87797cf084' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-72d5040f-ff26-4e3d-83ab-84d1f04c602c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-72d5040f-ff26-4e3d-83ab-84d1f04c602c' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-17e53eab-bf26-4ea5-96ad-d2a9f5490cde' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-17e53eab-bf26-4ea5-96ad-d2a9f5490cde' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "    good_wavelengths  (bands) float32 1kB ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-b1b699f4-766b-4d09-8cbe-1d22a07ce34c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-b1b699f4-766b-4d09-8cbe-1d22a07ce34c' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-3e1c77f1-41a1-4173-ac5a-c42885b8aba8' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3e1c77f1-41a1-4173-ac5a-c42885b8aba8' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-03e1951c-1120-435b-98d3-26366989e0bf' class='xr-section-summary-in' type='checkbox'  checked><label for='section-03e1951c-1120-435b-98d3-26366989e0bf' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-08f2a7d3-bd0d-41fc-a46a-7472dfe19761' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-08f2a7d3-bd0d-41fc-a46a-7472dfe19761' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-18d24452-7612-492f-a326-47d2a56a166a' class='xr-var-data-in' type='checkbox'><label for='data-18d24452-7612-492f-a326-47d2a56a166a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-d1b8ab05-42d0-4abd-ad53-beb2718843de' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d1b8ab05-42d0-4abd-ad53-beb2718843de' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b43dba25-5b67-415e-9df1-ff527de84b8e' class='xr-var-data-in' type='checkbox'><label for='data-b43dba25-5b67-415e-9df1-ff527de84b8e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-ca321b4b-ff16-471a-aec6-1147cd0ee4f9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ca321b4b-ff16-471a-aec6-1147cd0ee4f9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-df0b3402-29b5-4277-a4d8-8988208f56b0' class='xr-var-data-in' type='checkbox'><label for='data-df0b3402-29b5-4277-a4d8-8988208f56b0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3fba5e55-9e87-4cbb-8a80-8dd5f46c7edd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3fba5e55-9e87-4cbb-8a80-8dd5f46c7edd' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-ef9fd5ca-497d-456e-afec-d21e885c1e22' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-ef9fd5ca-497d-456e-afec-d21e885c1e22' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 3kB\n",
@@ -573,7 +579,7 @@
        "    good_wavelengths  (bands) float32 1kB ..."
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/docs/howto/edl.ipynb
+++ b/docs/howto/edl.ipynb
@@ -30,17 +30,11 @@
    "metadata": {},
    "source": [
     "### Data in AWS\n",
-    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "3108ff21-1ea2-449b-b2f5-b442dd3b61f5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s3_credentials = auth.get_s3_credentials(\"NSIDC\")"
+    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs:\n",
+    "\n",
+    "```\n",
+    "s3_credentials = auth.get_s3_credentials(\"NSIDC\")\n",
+    "```"
    ]
   },
   {

--- a/docs/howto/edl.ipynb
+++ b/docs/howto/edl.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "source": [
     "### Data in AWS\n",
-    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs:\n",
+    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs. This line is commented out for security reasons. Please copy the following line into a new code block in order to obtain your credentials. \n",
     "\n",
     "```\n",
     "s3_credentials = auth.get_s3_credentials(\"NSIDC\")\n",

--- a/docs/howto/edl.ipynb
+++ b/docs/howto/edl.ipynb
@@ -17,17 +17,7 @@
    "execution_count": 1,
    "id": "ce723d6f-8b5f-43e1-9531-19ee08a056fe",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You're now authenticated with NASA Earthdata Login\n",
-      "Using token with expiration date: 09/25/2023\n",
-      "Using environment variables for EDL\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import earthaccess\n",
     "\n",
@@ -40,32 +30,17 @@
    "metadata": {},
    "source": [
     "### Data in AWS\n",
-    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs"
+    "If the data we want to access is on AWS, we can use earthaccess to generate temporary S3 credentials for any of the DAACs. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "3108ff21-1ea2-449b-b2f5-b442dd3b61f5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'accessKeyId': 'ASIA2D3OGJNTE2UAIDHR',\n",
-       " 'secretAccessKey': '9+6D3m76HTuNi3qvbgUMBFlJECsCgPyJ4ur2CfZL',\n",
-       " 'sessionToken': 'FwoGZXIvYXdzEPL//////////wEaDIVnMBd6zBaEKmG58CLpAXrPN52vpRHvs+0y960kNwGOdFHPD81WVsdeUciP/vQvsU/xX4Cg+iLH/OXDlH/PBWCmSgfk4vgXD9k6r2JRmnpkwyF4v4K4+ciIuUHNG43ZegSFtkzZoLHShLtEnNu/OIT0TlcrOLJIY+TnjEDcKkXiLSsLYB7qDKZIeg654oPCkjeXyDuoWOumJa7utBEwHmakOGdGJTthOfbfJ6RJ9sbPbmsEXg0bHF5PY9h3/Eoq0rjyRmlb1WYuopw5YK8dL5N9IwSKlKiu19Cj0nd04XVNuiB02+fLDubsnKK1b3j0jR53qAU3FxobKLHgj6YGMi0kDN7xWP6yqI7Ry69Lf5EEcDRVp4UVz6llGYoDpsKr9s3cXaBljkhEjH7N5dQ=',\n",
-       " 'expiration': '2023-07-28 17:43:29+00:00'}"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "s3_credentials = auth.get_s3_credentials(\"NSIDC\")\n",
-    "s3_credentials"
+    "s3_credentials = auth.get_s3_credentials(\"NSIDC\")"
    ]
   },
   {
@@ -88,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "id": "a7bb1a93-6f85-40cd-93b4-ce821a03a8b5",
    "metadata": {},
    "outputs": [],
@@ -102,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "c0f4e286-8ce9-4cde-b3a2-631b361a0d51",
    "metadata": {},
    "outputs": [
@@ -112,7 +87,7 @@
        "'�HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00���������HUn\\x00\\x00\\x00\\x00��������\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR\\x02'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -133,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "id": "1e5f5f7a-0643-42cb-b70c-4ac982824ff9",
    "metadata": {},
    "outputs": [],
@@ -143,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "fbc7bc5f-b984-4324-b095-3648a437fba2",
    "metadata": {},
    "outputs": [
@@ -153,7 +128,7 @@
        "b'\\x89HDF\\r\\n\\x1a\\n\\x00\\x00\\x00\\x00\\x00\\x08\\x08\\x00\\x04\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xd7HUn\\x00\\x00\\x00\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00`\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00OHDR'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -166,19 +141,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "07433a9f-f276-4d2b-9ed3-f556df2884af",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f68d214c1c4b4d0fb0b44d878a003a33",
+       "model_id": "ac15458d5f9e4b8aac40f2e5417b22c7",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "QUEUEING TASKS | : 0it [00:00, ?it/s]"
+       "QUEUEING TASKS | :   0%|          | 0/1 [00:00<?, ?it/s]"
       ]
      },
      "metadata": {},
@@ -187,7 +162,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "185025ed0c284481982459d85c8dbb1f",
+       "model_id": "100cb212635146bab6548c8bf171d970",
        "version_major": 2,
        "version_minor": 0
       },
@@ -201,7 +176,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec660bd64a284df28a03705f56eea208",
+       "model_id": "3754ed8d0297407cade522b651c59ead",
        "version_major": 2,
        "version_minor": 0
       },
@@ -216,8 +191,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 983 ms, sys: 101 ms, total: 1.08 s\n",
-      "Wall time: 18.3 s\n"
+      "CPU times: user 2.73 s, sys: 241 ms, total: 2.97 s\n",
+      "Wall time: 10.9 s\n"
      ]
     },
     {
@@ -586,25 +561,25 @@
        "  stroke: currentColor;\n",
        "  fill: currentColor;\n",
        "}\n",
-       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 3kB\n",
        "Dimensions:           (bands: 285)\n",
        "Dimensions without coordinates: bands\n",
        "Data variables:\n",
-       "    wavelengths       (bands) float32 ...\n",
-       "    fwhm              (bands) float32 ...\n",
-       "    good_wavelengths  (bands) float32 ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-5bccc958-c146-4c96-bff3-3bb1192cabe4' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5bccc958-c146-4c96-bff3-3bb1192cabe4' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-1762f4af-4275-4de2-a60b-212974a37714' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1762f4af-4275-4de2-a60b-212974a37714' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-a0ec6ab2-8789-423c-b8a5-68b7ad70c280' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a0ec6ab2-8789-423c-b8a5-68b7ad70c280' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-e0a4ffbe-5053-4b11-a89a-cac8825f524d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e0a4ffbe-5053-4b11-a89a-cac8825f524d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d5354c83-0276-431a-913a-bcd675945ac4' class='xr-var-data-in' type='checkbox'><label for='data-d5354c83-0276-431a-913a-bcd675945ac4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-3c8797e7-1c1b-4423-ae85-057084395786' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3c8797e7-1c1b-4423-ae85-057084395786' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a54f045f-96b6-49c5-9266-e5615af70a7f' class='xr-var-data-in' type='checkbox'><label for='data-a54f045f-96b6-49c5-9266-e5615af70a7f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-93a19519-a78f-4b37-9b63-fd503a602141' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-93a19519-a78f-4b37-9b63-fd503a602141' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-74aa0491-8340-4332-a2cc-d85b7aa96407' class='xr-var-data-in' type='checkbox'><label for='data-74aa0491-8340-4332-a2cc-d85b7aa96407' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2e739f0a-61b0-4394-9f22-6e6de6d1b193' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2e739f0a-61b0-4394-9f22-6e6de6d1b193' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-db876828-0745-4d96-a611-e74dbe3f8be3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-db876828-0745-4d96-a611-e74dbe3f8be3' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "    wavelengths       (bands) float32 1kB ...\n",
+       "    fwhm              (bands) float32 1kB ...\n",
+       "    good_wavelengths  (bands) float32 1kB ...</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-a77454ce-32d9-4909-8c2f-c3a69f1acf05' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-a77454ce-32d9-4909-8c2f-c3a69f1acf05' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span>bands</span>: 285</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-3e7c8c34-32f3-4201-a03b-bdc984c1cbc2' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3e7c8c34-32f3-4201-a03b-bdc984c1cbc2' class='xr-section-summary'  title='Expand/collapse section'>Coordinates: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-a6f008f4-112b-4032-a4f8-71aeda7d1911' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a6f008f4-112b-4032-a4f8-71aeda7d1911' class='xr-section-summary' >Data variables: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-a1e99f53-de37-49f4-801b-28a334707122' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a1e99f53-de37-49f4-801b-28a334707122' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-555eb7e3-7b9c-4e1a-aa4f-723a6321f4f8' class='xr-var-data-in' type='checkbox'><label for='data-555eb7e3-7b9c-4e1a-aa4f-723a6321f4f8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelength Centers</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>fwhm</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-92f72bbe-e94a-4cce-a3b1-491e689450e5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-92f72bbe-e94a-4cce-a3b1-491e689450e5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2fe6397f-1398-4e1f-b838-45a166683893' class='xr-var-data-in' type='checkbox'><label for='data-2fe6397f-1398-4e1f-b838-45a166683893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Full Width at Half Max</dd><dt><span>units :</span></dt><dd>nm</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>good_wavelengths</span></div><div class='xr-var-dims'>(bands)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>...</div><input id='attrs-48051428-22ff-4a40-85e7-27ff7c18a3c7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-48051428-22ff-4a40-85e7-27ff7c18a3c7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f4b76c8f-6015-4870-a7e7-e21a6b65eaa4' class='xr-var-data-in' type='checkbox'><label for='data-f4b76c8f-6015-4870-a7e7-e21a6b65eaa4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Wavelengths where reflectance is useable: 1 = good data, 0 = bad data</dd><dt><span>units :</span></dt><dd>unitless</dd></dl></div><div class='xr-var-data'><pre>[285 values with dtype=float32]</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-dc6c043e-46f6-4544-be92-b2f94b99f0fd' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-dc6c043e-46f6-4544-be92-b2f94b99f0fd' class='xr-section-summary'  title='Expand/collapse section'>Indexes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'></ul></div></li><li class='xr-section-item'><input id='section-5dbe57d8-f873-48bb-8e68-b27e57402e7b' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5dbe57d8-f873-48bb-8e68-b27e57402e7b' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
-       "<xarray.Dataset>\n",
+       "<xarray.Dataset> Size: 3kB\n",
        "Dimensions:           (bands: 285)\n",
        "Dimensions without coordinates: bands\n",
        "Data variables:\n",
-       "    wavelengths       (bands) float32 ...\n",
-       "    fwhm              (bands) float32 ...\n",
-       "    good_wavelengths  (bands) float32 ..."
+       "    wavelengths       (bands) float32 1kB ...\n",
+       "    fwhm              (bands) float32 1kB ...\n",
+       "    good_wavelengths  (bands) float32 1kB ..."
       ]
      },
-     "execution_count": 13,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Moving s3credential guidance into markdown for security reasons. This will remove expired aws keys from the notebook.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--745.org.readthedocs.build/en/745/

<!-- readthedocs-preview earthaccess end -->