### PR TITLE
Allow maintainers to run integration tests on PR from a fork

### DIFF
--- a/.github/actions/install-pkg/action.yml
+++ b/.github/actions/install-pkg/action.yml
@@ -3,6 +3,7 @@ description: Install earthaccess Python package and testing dependencies
 
 inputs:
   python-version:
+    description: Version of Python to use
     required: true
 
 runs:
@@ -16,7 +17,7 @@ runs:
     - name: Display full python version
       shell: bash
       id: full-python-version
-      run: echo "{version}=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
+      run: echo "version=$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")" >> $GITHUB_OUTPUT
 
     - name: Install package and test dependencies
       shell: bash

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,6 +2,7 @@ name: Integration Tests
 
 on:
   pull_request:
+  pull_request_target:
   push:
     branches:
       - main
@@ -19,6 +20,25 @@ concurrency:
 
 jobs:
   integration-tests:
+    #
+    # This condition prevents DUPLICATE attempts to run integration tests for
+    # PRs coming from FORKS.
+    #
+    # When a PR originates from a fork, both a pull_request and a
+    # pull_request_target event are triggered.  This means that without a
+    # condition, GitHub will attempt to run integration tests TWICE, once for
+    # each event.
+    #
+    # To prevent this, this condition ensures that integration tests are run
+    # in only ONE of the following cases:
+    #
+    #   1. The event is NOT a pull_request.  This covers the case when the event
+    #      is a pull_request_target (i.e., a PR from a fork), as well as all
+    #      other cases listed in the "on" block at the top of this file.
+    #   2. The event IS a pull_request AND the base repo and head repo are the
+    #      same (i.e., the PR is NOT from a fork).
+    #
+    if: github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,13 +46,35 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Fetch user permission
+        id: permission
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
 
-      - uses: ./.github/actions/install-pkg
+      - name: Check user permission
+        if: ${{ steps.permission.outputs.require-result == 'false' }}
+        # If the triggering actor does not have write permission (i.e., this is a
+        # PR from a fork), then we exit, otherwise most of the integration tests will
+        # fail because they require access to secrets.  In this case, a maintainer
+        # will need to make sure the PR looks safe, and if so, manually re-run the
+        # failed pull_request_target jobs.
+        run: |
+          echo "User **${{ github.triggering_actor }}** does not have permission to run integration tests." >> $GITHUB_STEP_SUMMARY
+          echo "A maintainer must perform a security review and re-run this build, if the code is safe." >> $GITHUB_STEP_SUMMARY
+          echo "See [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests)." >> $GITHUB_STEP_SUMMARY
+          exit 1
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install package with dependencies
+        uses: ./.github/actions/install-pkg
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Test
+      - name: Run integration tests
         env:
           EARTHDATA_USERNAME: ${{ secrets.EDL_USERNAME }}
           EARTHDATA_PASSWORD: ${{ secrets.EDL_PASSWORD }}
@@ -40,7 +82,7 @@ jobs:
           EARTHACCESS_TEST_PASSWORD: ${{ secrets.EDL_PASSWORD }}
         run: ./scripts/integration-test.sh
 
-      - name: Upload coverage
+      - name: Upload coverage report
         # Don't upload coverage when using the `act` tool to run the workflow locally
         if: ${{ !env.ACT }}
         uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,8 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout sources
+        uses: actions/checkout@v4
 
       - uses: ./.github/actions/install-pkg
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .ipynb_checkpoints
 .python-version
 .mypy_cache
+.nox/
 __pycache__
 .pytest_cache
 htmlcov

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -33,19 +33,20 @@ environment for each run.
 
 ## Manual development environment setup
 
-While `nox` is the fastest way to get started, you may soon find that you need a full
-development environment, for example to test in a REPL. This development environment
-also includes `nox`.
+While `nox` is the fastest way to get started, you will likely need a full
+development environment for making code contributions, for example to test in a
+REPL, or to resolve references in your favorite IDE.  This development
+environment also includes `nox`.
 
-Create and activate a virtual environment with `venv`, which comes by default with
-Python, in the `.venv` directory:
+Create and activate a virtual environment with `venv`, which comes by default
+with Python, in the `.venv` directory:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
 ```
 
-Install _earthaccess_ in editable mode with optional development dependencies:
+Install `earthaccess` in editable mode with optional development dependencies:
 
 ```bash
 pip install --editable ".[dev,test,docs]"
@@ -53,8 +54,8 @@ pip install --editable ".[dev,test,docs]"
 
 ??? note "For conda users"
 
-    For your convenience, there is a `environment.yml` file at the root of this
-    repository. You can create a dev environment quickly with:
+    For your convenience, there is an `environment.yml` file at the root of this
+    repository, allowing you to create a conda environment quickly, as follows:
 
     ```bash
     conda env create --file environment.yml
@@ -62,6 +63,6 @@ pip install --editable ".[dev,test,docs]"
 
 ## Managing Dependencies
 
-If you need to add a new dependency, edit `pyproject.toml` and insert the dependency in
-the correct location (either in the `dependencies` array or
-`[project.optional-dependencies]`.
+If you need to add a new dependency, edit `pyproject.toml` and insert the
+dependency in the correct location (either in the `dependencies` array or under
+`[project.optional-dependencies]`).

--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,7 @@ dependencies:
   - pip
   - pip:
       - --editable .[dev,test,docs]
+variables:
+  # Allow pip installs when conda environment is active
+  PIP_REQUIRE_VENV: 0
+  PIP_REQUIRE_VIRTUALENV: 0

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ import nox
 DIR = Path(__file__).parent.resolve()
 
 nox.needs_version = ">=2024.3.2"
-nox.options.sessions = ["typecheck", "test_unit"]
+nox.options.sessions = ["typecheck", "tests"]
 nox.options.default_venv_backend = "uv|virtualenv"
 
 
@@ -20,7 +20,7 @@ def typecheck(session: nox.Session) -> None:
 
 
 @nox.session
-def test_unit(session: nox.Session) -> None:
+def tests(session: nox.Session) -> None:
     """Run the unit tests."""
     session.install("--editable", ".[test]")
     session.run("pytest", "tests/unit", *session.posargs)


### PR DESCRIPTION
This PR fixes the problem of failing integration tests on PRs from forked repos by allowing maintainers to review such PRs for potential security issues (which should be minimal for trusted/known contributors) and then re-running the failed jobs such that they may successfully run.

The result is the following:

1. In the integration test job, the permissions of the user (actor) triggering the PR are checked. If the user does not have write access to this repo, the job is immediately failed, thus avoiding any attempt to run integration tests, which would only fail anyway because without write permission, the secrets required by the integration tests cannot be read.
2. The job summary for the failed integration tests describe the problem (i.e., the triggering user does not have permission to run int. tests, and a maintainer must perform a security review of the PR, and re-run the failed jobs if there are no security concerns).
3. After a maintainer determines there are no security concerns, the maintainer can re-run the failed build, which will allow the integration jobs to run with the necessary permission to read secrets so that the integration tests may succeed.
4. Once the integration tests succeed, there is no longer a need for a maintainer to bypass failing integration tests in the hope that they will pass once the PR is merged.

Since this change must land on the `main` branch before it takes effect, I tested this with a fork from my fork to confirm that it does indeed work as expected. This should mean that this PR should be the last PR a maintainer will have to bypass failing integration tests to merge it.

<!--
Replace this text, including the symbols above and below it, with descriptive text about
the change you are proposing. Please include a reference to any issues addressed or
resolved in that text, for example "resolves #1".
-->

<!--
IMPORTANT: As a contributor, we would like as much help as you can offer, but we only
expect you to complete the steps in the "PR draft checklist" below. Maintainers are
willing and ready to help pick it up from there!

Please start by opening this Pull Request as a "draft". You can do this by
clicking the arrow on the right side of the green "Create pull request" button. While
your pull request is in "draft" state, maintainers will assume the PR isn't ready for
their attention unless they are specifically summoned using GitHub's @ system.

Follow the draft checklist below to move the PR out of draft state. If you accidentally
created the PR as a non-draft, don't worry, you can still change it to a draft using the
"Convert to draft" button on  the right side panel under the "Reviewers" section.
-->

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [ ] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [ ] Ensure an issue exists representing the problem being solved in this PR.
- [ ] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
- [ ] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>

Fixes #810

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--818.org.readthedocs.build/en/818/

<!-- readthedocs-preview earthaccess end -->