### PR TITLE
Replace EarthAccessFile with classes inheriting from specific AbstractBufferedFile subclasses

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -3,6 +3,7 @@ import logging
 import requests
 import s3fs
 from fsspec import AbstractFileSystem
+from fsspec.spec import AbstractBufferedFile
 from typing_extensions import Any, Dict, List, Optional, Union, deprecated
 
 import earthaccess
@@ -11,7 +12,7 @@ from earthaccess.services import DataServices
 from .auth import Auth
 from .results import DataCollection, DataGranule
 from .search import CollectionQuery, DataCollections, DataGranules, GranuleQuery
-from .store import EarthAccessFile, Store
+from .store import Store
 from .system import PROD, System
 from .utils import _validation as validate
 
@@ -242,7 +243,7 @@ def download(
 def open(
     granules: Union[List[str], List[DataGranule]],
     provider: Optional[str] = None,
-) -> List[EarthAccessFile]:
+) -> List[AbstractBufferedFile]:
     """Returns a list of file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.
 

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -137,6 +137,7 @@ class TestStoreOpen(VCRTestCase):
         return myvcr
 
     def test_round_trip_granules_pickle(self):
+        earthaccess.login(strategy="netrc")
         granules = earthaccess.search_data(
             short_name="VIIRSJ1_L3m_CHL",
             granule_name="*.9km.*",
@@ -147,6 +148,7 @@ class TestStoreOpen(VCRTestCase):
         assert open_files == pickle.loads(serialized)
 
     def test_round_trip_urls_pickle(self):
+        earthaccess.login(strategy="netrc")
         granules = earthaccess.search_data(
             short_name="VIIRSJ1_L3m_CHL",
             granule_name="*.9km.*",


### PR DESCRIPTION
Fixes #610

This PR provides an "explicit is better than implicit" solution to fixing the method resolution order (MRO) on the (now former) `EarthAccessFile` (#610). The bug was that `EarthAccessFile` tried to proxy both `s3fs.S3File` and `fsspec.implmentations.http.HTTPFile`, but failed to proxy those methods also defined on the superclass `fsspec.spec.AbstractBufferedFile` from which all three inherited. My first attempted fix (PR #620) removed `fsspec.spec.AbstractBufferedFile` from the MRO of `EarthAccessFile`. While this did proxy methods correctly, usage was broadly broken because each `EarthAccessFile` was no longer an instance of the file-like object proxied (which was important, in particular for `xarray.open_dataset`!).

Why proxy at all? The file-like objects that `earthaccess.open` provides must be pickleable AND the un-pickling process needs to be able to change the particular type of file-like object used, an essential part of the hand-off of file-like objects between xarray running locally and dask workers in the cloud.

What this PR does:
- replaces `class EarthAccessFile(fsspec.spec.AbstractBufferedFile)` with a suite of (currently three) classes that could be returned by `fs.open` where `fs` is either an `S3FileSystem` or an `HTTPFileSystem`.
  - `EarthaccessS3File(EarthaccessMixin, S3File)`
  - `EarthaccessHTTPFile(EarthaccessMixin, HTTPFile)`
  - `EarthaccessHTTPStreamFile(EarthaccessMixin, HTTPStreamFile)`
- adds the `EarthaccessMixin` to implement the `__reduce__` method for custom pickling
- replace the logic of the `__reduce__` callable, the `make_instance` function, to avoid "double pickling" (no more `dumps`)

**NOTE: Because #620 was merged, the "Files changed" in this PR are misleading relative to the original implementation. The best commit to reference for comparison is from [right before the merge](https://github.com/nsidc/earthaccess/tree/4510ac135c3fb864c7ff07fc9493a3fa47e2f3ad).**

Still in progress:
- [ ] documentation (both user documentation and code comments)
- [ ] the new tests need to be integration tests rather than unit tests (i think) to use earthdata authentication

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Ensure an issue exists representing the problem being solved in this PR.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--828.org.readthedocs.build/en/828/

<!-- readthedocs-preview earthaccess end -->