### PR TITLE
restore AbstractBaseClass inheritance

### DIFF
--- a/docs/user-reference/store/earthaccessfile.md
+++ b/docs/user-reference/store/earthaccessfile.md
@@ -1,7 +1,0 @@
-# Documentation for `EarthAccessFile`
-
-::: earthaccess.store.EarthAccessFile
-    options:
-      inherited_members: true
-    show_root_heading: true
-    show_source: false

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -242,7 +242,7 @@ def download(
 def open(
     granules: Union[List[str], List[DataGranule]],
     provider: Optional[str] = None,
-) -> List[EarthAccessFile]:
+) -> List[AbstractFileSystem]:
     """Returns a list of file-like objects that can be used to access files
     hosted on S3 or HTTPS by third party libraries like xarray.
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -26,7 +26,7 @@ from .search import DataCollections
 logger = logging.getLogger(__name__)
 
 
-class EarthAccessFile:
+class EarthAccessFile(fsspec.spec.AbstractBaseFile):
     """Handle for a file-like object pointing to an on-prem or Earthdata Cloud granule."""
 
     def __init__(
@@ -64,7 +64,7 @@ def _open_files(
     url_mapping: Mapping[str, Union[DataGranule, None]],
     fs: fsspec.AbstractFileSystem,
     threads: Optional[int] = 8,
-) -> List[EarthAccessFile]:
+) -> List[fsspec.spec.AbstractBaseFile]:
     def multi_thread_open(data: tuple) -> EarthAccessFile:
         urls, granule = data
         return EarthAccessFile(fs.open(urls), granule)
@@ -336,7 +336,7 @@ class Store(object):
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-    ) -> List[EarthAccessFile]:
+    ) -> List[fsspec.spec.AbstractBaseFile]:
         """Returns a list of file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -26,7 +26,7 @@ from .search import DataCollections
 logger = logging.getLogger(__name__)
 
 
-class EarthAccessFile(fsspec.spec.AbstractBaseFile):
+class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
     """Handle for a file-like object pointing to an on-prem or Earthdata Cloud granule."""
 
     def __init__(
@@ -64,7 +64,7 @@ def _open_files(
     url_mapping: Mapping[str, Union[DataGranule, None]],
     fs: fsspec.AbstractFileSystem,
     threads: Optional[int] = 8,
-) -> List[fsspec.spec.AbstractBaseFile]:
+) -> List[fsspec.spec.AbstractBufferedFile]:
     def multi_thread_open(data: tuple) -> EarthAccessFile:
         urls, granule = data
         return EarthAccessFile(fs.open(urls), granule)
@@ -336,7 +336,7 @@ class Store(object):
         self,
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
-    ) -> List[fsspec.spec.AbstractBaseFile]:
+    ) -> List[fsspec.spec.AbstractBufferedFile]:
         """Returns a list of file-like objects that can be used to access files
         hosted on S3 or HTTPS by third party libraries like xarray.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,7 +101,6 @@ nav:
               - "Granule Queries": "user-reference/granules/granules-query.md"
               - "Granule Results": "user-reference/granules/granules.md"
           - Store:
-              - "EarthAccessFile": "user-reference/store/earthaccessfile.md"
               - "Store": "user-reference/store/store.md"
           - Auth:
               - "Auth": "user-reference/auth/auth.md"

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -129,6 +129,9 @@ class TestStoreSessions(unittest.TestCase):
         return None
 
 
+@pytest.mark.xfail(
+    reason="This test reproduces a bug (#610) which has not yet been fixed."
+)
 def test_earthaccess_file_getattr():
     fs = fsspec.filesystem("memory")
     with fs.open("/foo", "wb") as f:


### PR DESCRIPTION
A hackday quick fix with @nikki-t and @mfisher87 to undo the bad effects of #620. Conversation continues about the original bug report (#610).

What this PR does:
- adds the `fsspec.spec.AbstractBufferedFile` parent class (back) to `EarthAccessFile`
- marks the `test_earthaccess_file_getattr` test as expected fail because we re-introduce #610.