### PR TITLE
Fix pqdm_kwargs integration tests

### DIFF
--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 import requests
 import s3fs
@@ -202,9 +203,10 @@ def login(strategy: str = "all", persist: bool = False, system: System = PROD) -
 
 def download(
     granules: Union[DataGranule, List[DataGranule], str, List[str]],
-    local_path: Optional[str],
+    local_path: Optional[Union[Path, str]] = None,
     provider: Optional[str] = None,
     threads: int = 8,
+    *,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[str]:
     """Retrieves data granules from a remote storage system.
@@ -215,7 +217,11 @@ def download(
 
     Parameters:
         granules: a granule, list of granules, a granule link (HTTP), or a list of granule links (HTTP)
-        local_path: local directory to store the remote data granules
+        local_path: Local directory to store the remote data granules.  If not
+            supplied, defaults to a subdirectory of the current working directory
+            of the form `data/YYYY-MM-DD-UUID`, where `YYYY-MM-DD` is the year,
+            month, and day of the current date, and `UUID` is the last 6 digits
+            of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
@@ -228,31 +234,29 @@ def download(
     Raises:
         Exception: A file download failed.
     """
-    provider = _normalize_location(provider)
-    pqdm_kwargs = {
-        "exception_behavior": "immediate",
-        "n_jobs": threads,
-        **(pqdm_kwargs or {}),
-    }
+    provider = _normalize_location(str(provider))
+
     if isinstance(granules, DataGranule):
         granules = [granules]
     elif isinstance(granules, str):
         granules = [granules]
+
     try:
-        results = earthaccess.__store__.get(
-            granules, local_path, provider, threads, pqdm_kwargs
+        return earthaccess.__store__.get(
+            granules, local_path, provider, threads, pqdm_kwargs=pqdm_kwargs
         )
     except AttributeError as err:
         logger.error(
             f"{err}: You must call earthaccess.login() before you can download data"
         )
-        return []
-    return results
+
+    return []
 
 
 def open(
     granules: Union[List[str], List[DataGranule]],
     provider: Optional[str] = None,
+    *,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of file-like objects that can be used to access files
@@ -269,15 +273,11 @@ def open(
     Returns:
         A list of "file pointers" to remote (i.e. s3 or https) files.
     """
-    provider = _normalize_location(provider)
-    pqdm_kwargs = {
-        "exception_behavior": "immediate",
-        **(pqdm_kwargs or {}),
-    }
-    results = earthaccess.__store__.open(
-        granules=granules, provider=provider, pqdm_kwargs=pqdm_kwargs
+    return earthaccess.__store__.open(
+        granules=granules,
+        provider=_normalize_location(provider),
+        pqdm_kwargs=pqdm_kwargs,
     )
-    return results
 
 
 def get_s3_credentials(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,10 +1,15 @@
-from unittest.mock import Mock
+from pathlib import Path
+from unittest.mock import patch
 
 import earthaccess
 import pytest
 
 
-def test_download_immediate_failure(monkeypatch):
+def fail_to_download_file(*args, **kwargs):
+    raise IOError("Download failed")
+
+
+def test_download_immediate_failure(tmp_path: Path):
     earthaccess.login()
 
     results = earthaccess.search_data(
@@ -14,37 +19,32 @@ def test_download_immediate_failure(monkeypatch):
         count=10,
     )
 
-    def mock_get(*args, **kwargs):
-        raise Exception("Download failed")
-
-    mock_store = Mock()
-    monkeypatch.setattr(earthaccess, "__store__", mock_store)
-    monkeypatch.setattr(mock_store, "get", mock_get)
-
-    with pytest.raises(Exception, match="Download failed"):
-        earthaccess.download(results, "/home/download-folder")
+    with patch.object(earthaccess.__store__, "_download_file", fail_to_download_file):
+        with pytest.raises(IOError, match="Download failed"):
+            earthaccess.download(results, str(tmp_path))
 
 
-def test_download_deferred_failure(monkeypatch):
+def test_download_deferred_failure(tmp_path: Path):
     earthaccess.login()
 
+    count = 3
     results = earthaccess.search_data(
         short_name="ATL06",
         bounding_box=(-10, 20, 10, 50),
         temporal=("1999-02", "2019-03"),
-        count=10,
+        count=count,
     )
 
-    def mock_get(*args, **kwargs):
-        return [Exception("Download failed")] * len(results)
+    with patch.object(earthaccess.__store__, "_download_file", fail_to_download_file):
+        with pytest.raises(Exception) as exc_info:
+            earthaccess.download(
+                results,
+                tmp_path,
+                None,
+                8,
+                pqdm_kwargs={"exception_behaviour": "deferred"},
+            )
 
-    mock_store = Mock()
-    monkeypatch.setattr(earthaccess, "__store__", mock_store)
-    monkeypatch.setattr(mock_store, "get", mock_get)
-
-    results = earthaccess.download(
-        results, "/home/download-folder", None, 8, {"exception_behavior": "deferred"}
-    )
-
-    assert all(isinstance(e, Exception) for e in results)
-    assert len(results) == 10
+    errors = exc_info.value.args
+    assert len(errors) == count
+    assert all(isinstance(e, IOError) and str(e) == "Download failed" for e in errors)


### PR DESCRIPTION
Integration tests are failing, with many errors of the following form:

```plain
FAILED tests/integration/test_cloud_open.py::test_***_can_open_onprem_collection_granules[daac1] - NotImplementedError: granules should be a list of DataGranule or URLs
```

This PR fixes this issue, although it's odd that the integration tests did not fail prior to the code landing on `main` that is now causing this problem.

It turns out to be an issue with use of singledispatch, and having registered functions with signatures that differed (accidentally, it seems) by more than simply a difference of type of the first argument.