### PR TITLE
Fix monthly issue metrics workflow

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   build:
@@ -44,6 +45,9 @@ jobs:
           content-filepath: ./issue_metrics.md
 
       - name: Close Issue
-        run: gh issue close "${{steps.create_issue.outputs.issue-number}}" --reason "not planned"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue close "${{steps.create_issue.outputs.issue-number}}" \
+            --reason "not planned" \
+            --repo ${{ github.repository }}


### PR DESCRIPTION
Our monthly issue metrics GitHub Actions workflow is supposed to close the issue once created, but fails to do so:
https://github.com/nsidc/earthaccess/actions/runs/11623230080/job/32369942886#step:6:10

Failure was because we didn't specify the repo so it tried to base it on a local git repository, but there wasn't one because we don't need to check out the repository for the rest of the action steps.

I've updated the action to have  issue write permission (needed for the issue  PATCH API request)  as well as specifying the repo, which I confirm works in a directory with no git repository:
```
$ gh issue close 861 --reason "not planned" --repo nsidc/earthaccess
✓ Closed issue nsidc/earthaccess#861 (Monthly issue metrics report: 2024-10-01..2024-10-31)
```

I don't think there's much value to a changelog entry here, so I've not added one; happy to add one if anyone thinks otherwise.


<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] ~~Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`.~~ If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] ~~Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any.~~ Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--867.org.readthedocs.build/en/867/

<!-- readthedocs-preview earthaccess end -->