### PR TITLE
Fix Incorrect Earthdata Login Hyperlinks

### DIFF
--- a/docs/tutorials/restricted-datasets.ipynb
+++ b/docs/tutorials/restricted-datasets.ipynb
@@ -12,7 +12,7 @@
     "## <img src=\"https://logos-world.net/wp-content/uploads/2020/05/NASA-Logo-1959-present.png\" width=\"100px\" align=\"middle\" /> NASA Earthdata API Client 🌍\n",
     "\n",
     "\n",
-    "> Note: Before we can use `earthaccess` we need an account with **[NASA EDL](https://urs.earthaccess.nasa.gov/)**\n"
+    "> Note: Before we can use `earthaccess` we need an account with **[NASA EDL](https://urs.earthdata.nasa.gov/)**\n"
    ]
   },
   {

--- a/notebooks/Demo.ipynb
+++ b/notebooks/Demo.ipynb
@@ -526,7 +526,7 @@
     "\n",
     "**CMR** API documentation: https://cmr.earthaccess.nasa.gov/search/site/docs/search/api.html\n",
     "\n",
-    "**EDL** API documentation: https://urs.earthaccess.nasa.gov/\n",
+    "**EDL** API documentation: https://urs.earthdata.nasa.gov/documentation\n",
     "\n",
     "NASA OpenScapes: https://nasa-openscapes.github.io/earthaccess-cloud-cookbook/\n",
     "\n",


### PR DESCRIPTION
This PR corrects two incorrect documentation hyperlinks to Earthdata Login.

- [x] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [x] Get at least one approving review.



<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--907.org.readthedocs.build/en/907/

<!-- readthedocs-preview earthaccess end -->