### PR TITLE
Thread-local Session Management and Cookie Reuse to Address EDL DSE issue

### DIFF
--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -127,7 +127,7 @@ class Store(object):
             oauth_profile = f"https://{auth.system.edl_hostname}/profile"
             # sets the initial URS cookie
             self._requests_cookies: Dict[str, Any] = {}
-            self.set_requests_session(oauth_profile)
+            self.set_requests_session(oauth_profile, bearer_token=True)
             if pre_authorize:
                 # collect cookies from other DAACs
                 for url in DAAC_TEST_URLS:

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -659,14 +659,17 @@ class Store(object):
 
     def _clone_session_in_local_thread(
         self, original_session: SessionWithHeaderRedirection
-    ) -> SessionWithHeaderRedirection:
-        """Creates a new session that replicates the settings of the original session.
+    ) -> None:
+        """Clone the original session and store it in the local thread context.
+
+        This method creates a new session that replicates the headers, cookies, and authentication settings
+        from the provided original session. The new session is stored in a thread-local storage.
 
         Parameters:
-            original_session: The original session object to be cloned
+            original_session (SessionWithHeaderRedirection): The session to be cloned.
 
         Returns:
-            A new session that has the same headers, cookies, and auth as the original session.
+            None
         """
         if not hasattr(self.thread_locals, "local_thread_session"):
             local_thread_session = SessionWithHeaderRedirection()

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -668,7 +668,7 @@ class Store(object):
         Returns:
             A new session that has the same headers, cookies, and auth as the original session.
         """
-        if not hasattr(self.thread_locals, 'local_thread_session'):
+        if not hasattr(self.thread_locals, "local_thread_session"):
             local_thread_session = SessionWithHeaderRedirection()
             local_thread_session.headers.update(original_session.headers)
             local_thread_session.cookies.update(original_session.cookies)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -658,6 +658,14 @@ class Store(object):
     def _clone_session(
         self, original_session: SessionWithHeaderRedirection
     ) -> SessionWithHeaderRedirection:
+        """Creates a new session that replicates the settings of the original session.
+
+        Parameters:
+            original_session: The original session object to be cloned
+
+        Returns:
+            A new session that has the same headers, cookies, and auth as the original session.
+        """
         new_session = SessionWithHeaderRedirection()
         new_session.headers.update(original_session.headers)
         new_session.cookies.update(original_session.cookies)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -672,7 +672,7 @@ class Store(object):
         path = directory / Path(local_filename)
         if not path.exists():
             try:
-                session = self.auth.get_session()
+                session = self.get_requests_session()
                 with session.get(
                     url,
                     stream=True,

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -336,7 +336,10 @@ class Store(object):
         Returns:
             requests Session
         """
-        return self.auth.get_session()
+        if hasattr(self, "_http_session"):
+            return self._http_session
+        else:
+            raise AttributeError("The requests session hasn't been set up yet.")
 
     def open(
         self,

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -331,9 +331,6 @@ class Store(object):
         This HTTPS session can be used to download granules if we want to use a direct,
         lower level API.
 
-        Parameters:
-            bearer_token: if true, will be used for authenticated queries on CMR
-
         Returns:
             requests Session
         """

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -655,7 +655,9 @@ class Store(object):
                 data_links, local_path, pqdm_kwargs=pqdm_kwargs
             )
 
-    def _clone_session(self, original_session: SessionWithHeaderRedirection) -> SessionWithHeaderRedirection:
+    def _clone_session(
+        self, original_session: SessionWithHeaderRedirection
+    ) -> SessionWithHeaderRedirection:
         new_session = SessionWithHeaderRedirection()
         new_session.headers.update(original_session.headers)
         new_session.cookies.update(original_session.cookies)

--- a/tests/unit/test_store.py
+++ b/tests/unit/test_store.py
@@ -134,74 +134,79 @@ class TestStoreSessions(unittest.TestCase):
         return None
 
     @responses.activate
-    def test_session_cloning_and_file_download(self):
-        # Mock URLs and their responses
+    def test_session_reuses_token_download(self):
         mock_creds = {
             "accessKeyId": "sure",
             "secretAccessKey": "correct",
             "sessionToken": "whynot",
         }
-        urls = [f"https://example.com/file{i}" for i in range(1, 11)]
-        for i, url in enumerate(urls):
-            responses.add(
-                responses.GET, url, body=f"Content of file {i + 1}", status=200
-            )
+        test_cases = [
+            (2, 500),  # 2 threads, 500 files
+            (4, 400),  # 4 threads, 400 files
+            (8, 5000),  # 8 threads, 5k files
+        ]
+        for n_threads, n_files in test_cases:
+            with self.subTest(n_threads=n_threads, n_files=n_files):
+                urls = [f"https://example.com/file{i}" for i in range(1, n_files + 1)]
+                for i, url in enumerate(urls):
+                    responses.add(
+                        responses.GET, url, body=f"Content of file {i + 1}", status=200
+                    )
 
-        # Mock authentication and store setup
-        mock_auth = MagicMock()
-        mock_auth.authenticated = True
-        mock_auth.system.edl_hostname = "urs.earthdata.nasa.gov"  # Mock hostname
-        responses.add(
-            responses.GET,
-            "https://urs.earthdata.nasa.gov/profile",
-            json=mock_creds,
-            status=200,
-        )
+                mock_auth = MagicMock()
+                mock_auth.authenticated = True
+                mock_auth.system.edl_hostname = "urs.earthdata.nasa.gov"
+                responses.add(
+                    responses.GET,
+                    "https://urs.earthdata.nasa.gov/profile",
+                    json=mock_creds,
+                    status=200,
+                )
 
-        original_session = SessionWithHeaderRedirection()
-        original_session.cookies.set("sessionid", "mocked-session-id")
-        mock_auth.get_session.return_value = original_session
+                original_session = SessionWithHeaderRedirection()
+                original_session.cookies.set("sessionid", "mocked-session-cookie")
+                mock_auth.get_session.return_value = original_session
 
-        # Create the Store instance
-        store = Store(auth=mock_auth)
-        store.thread_locals = threading.local()  # Use real thread-local storage
+                store = Store(auth=mock_auth)
+                store.thread_locals = threading.local()  # Use real thread-local storage
 
-        # Track cloned sessions
-        cloned_sessions = set()
+                # Track cloned sessions
+                cloned_sessions = set()
 
-        def mock_clone_session_in_local_thread(original_session):
-            """Mock session cloning to track cloned sessions."""
-            if not hasattr(store.thread_locals, "local_thread_session"):
-                session = SessionWithHeaderRedirection()
-                session.cookies.update(original_session.cookies)
-                cloned_sessions.add(id(session))  # Track unique sessions by ID
-                store.thread_locals.local_thread_session = session
+                def mock_clone_session_in_local_thread(original_session):
+                    """Mock session cloning to track cloned sessions."""
+                    if not hasattr(store.thread_locals, "local_thread_session"):
+                        session = SessionWithHeaderRedirection()
+                        session.cookies.update(original_session.cookies)
+                        cloned_sessions.add(id(session))
+                        store.thread_locals.local_thread_session = session
 
-        with patch.object(
-            store,
-            "_clone_session_in_local_thread",
-            side_effect=mock_clone_session_in_local_thread,
-        ):
-            mock_directory = Path("/mock/directory")
-            downloaded_files = []
+                with patch.object(
+                    store,
+                    "_clone_session_in_local_thread",
+                    side_effect=mock_clone_session_in_local_thread,
+                ):
+                    mock_directory = Path("/mock/directory")
+                    downloaded_files = []
 
-            def mock_download_file(url):
-                """Mock file download to track downloaded files."""
-                # Ensure session cloning happens before downloading
-                store._clone_session_in_local_thread(original_session)
-                downloaded_files.append(url)
-                return mock_directory / f"{url.split('/')[-1]}"
+                    def mock_download_file(url):
+                        """Mock file download to track downloaded files."""
+                        # Ensure session cloning happens before downloading
+                        store._clone_session_in_local_thread(original_session)
+                        downloaded_files.append(url)
+                        return mock_directory / f"{url.split('/')[-1]}"
 
-            with patch.object(store, "_download_file", side_effect=mock_download_file):
-                # Test multi-threaded download with 2 threads
-                pqdm(urls, store._download_file, n_jobs=2)  # type: ignore
+                    with patch.object(
+                        store, "_download_file", side_effect=mock_download_file
+                    ):
+                        # Test multi-threaded download
+                        pqdm(urls, store._download_file, n_jobs=n_threads)  # type: ignore
 
-        # Verify sessions cloned
-        self.assertEqual(len(cloned_sessions), 2)  # 2 sessions, one per thread
+                # We make sure we reuse the token up to N threads
+                self.assertTrue(len(cloned_sessions) <= n_threads)
 
-        # Verify files downloaded
-        self.assertEqual(len(downloaded_files), 10)  # 10 files downloaded
-        self.assertCountEqual(downloaded_files, urls)  # All files accounted for
+                self.assertEqual(len(downloaded_files), n_files)  # 10 files downloaded
+                self.assertCountEqual(downloaded_files, urls)  # All files accounted for
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
This pull request addresses a DSE issue reported by Earthdata Login (EDL) during data download requests involving large amount of granules through EarthAccess. One issue was traced to EarthAccess creating a new session for each download instead of reusing the existing session cookie, which is intended to reduce the number of requests to EDL by the DAAC data distribution endpoint (TEA). This PR introduces changes to enhance session cookie handling within each thread, avoiding EDL requests from TEA in subsequent authenticated data downloads.

Key modifications in this PR include:

- Thread-local Session Management: Added `_clone_session_in_local_thread` method to clone and store sessions in thread-local storage.
- Cookie Reuse in Downloads: Adapted `_download_file` method to utilize thread-local session cookies and reduce redundant session creation within each thread.
- Session Handling: Updated `get_requests_session` to retrieve an existing session or raise an error if none exists.

Notes:
- This PR does not address the cookie reuse issue for same-region access. I can create a separate PR for that later.
- I did not add or adjust unit tests because the current test coverage is limited and does not include the modified methods.
-  I have issues running integration tests, so I am uncertain about their status with these changes.
- I didn't adjust the following PR template since I am not if my PR is fully applicable to it. Please advise if adjustments or compliance with the template are required.

<!--
Replace this text, including the symbols above and below it, with descriptive text about
the change you are proposing. Please include a reference to any issues addressed or
resolved in that text, for example "resolves #1".
-->

<!--
IMPORTANT: As a contributor, we would like as much help as you can offer, but we only
expect you to complete the steps in the "PR draft checklist" below. Maintainers are
willing and ready to help pick it up from there!

Please start by opening this Pull Request as a "draft". You can do this by
clicking the arrow on the right side of the green "Create pull request" button. While
your pull request is in "draft" state, maintainers will assume the PR isn't ready for
their attention unless they are specifically summoned using GitHub's @ system.

Follow the draft checklist below to move the PR out of draft state. If you accidentally
created the PR as a non-draft, don't worry, you can still change it to a draft using the
"Convert to draft" button on  the right side panel under the "Reviewers" section.
-->

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [ ] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [ ] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--909.org.readthedocs.build/en/909/

<!-- readthedocs-preview earthaccess end -->