### PR TITLE
Add a workflow for generating Hackday Github Discussion threads

### DIFF
--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -1,0 +1,46 @@
+name: Generate Discussion Thread for Hackdays
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-discussion-threads:
+    runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+      contents: read
+
+    steps:
+
+      - name: Generate the Hackathon title
+        run: |
+          DATE=$(date --iso-8601 | sed 's|-|/|g')
+          echo "DISCUSSION_TITLE=Hackathon $DATE" >> $GITHUB_ENV
+
+      - name: Set the Hackathon description
+        run: |
+          echo "DISCUSSION_BODY=Reporting out on earthaccess hack days. Use the 'comment' button at the very bottom to send a message. Additionally, consider sending issues and PRs relevant to your work to help make the job of future readers easier. It is okay to duplicate information here! Use the reply feature to have a discussion under any comment. Enjoy!" >> $GITHUB_ENV
+          
+
+      - name: Create Discussions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          REPOSITORY_ID: ""
+          CATEGORY_ID: ""
+        run: |
+         gh api graphql -f query="
+         mutation 
+          {createDiscussion
+            (
+              input: 
+                {
+                repositoryId: ${{ env.REPOSITORY_ID }}, 
+                categoryId: ${{ env.CATEGORY_ID }}, 
+                body: \"${{ env.DISCUSSION_BODY }}\", 
+                title: \"${{ env.DISCUSSION_TITLE }}\"
+                }
+            ) 
+            {
+              discussion {id}
+            }
+          }"

--- a/.github/workflows/discussions.yml
+++ b/.github/workflows/discussions.yml
@@ -20,27 +20,26 @@ jobs:
       - name: Set the Hackathon description
         run: |
           echo "DISCUSSION_BODY=Reporting out on earthaccess hack days. Use the 'comment' button at the very bottom to send a message. Additionally, consider sending issues and PRs relevant to your work to help make the job of future readers easier. It is okay to duplicate information here! Use the reply feature to have a discussion under any comment. Enjoy!" >> $GITHUB_ENV
-          
 
       - name: Create Discussions
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-          REPOSITORY_ID: ""
-          CATEGORY_ID: ""
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_ID: MDEwOlJlcG9zaXRvcnkzOTk4Njc1Mjk=
+          CATEGORY_ID: DIC_kwDOF9V-ic4CdYaN!
         run: |
-         gh api graphql -f query="
-         mutation 
-          {createDiscussion
-            (
-              input: 
-                {
-                repositoryId: ${{ env.REPOSITORY_ID }}, 
-                categoryId: ${{ env.CATEGORY_ID }}, 
-                body: \"${{ env.DISCUSSION_BODY }}\", 
-                title: \"${{ env.DISCUSSION_TITLE }}\"
-                }
-            ) 
-            {
-              discussion {id}
-            }
-          }"
+          gh api graphql -f query="
+          mutation
+           {createDiscussion
+             (
+               input:
+                 {
+                 repositoryId: \"${{ env.REPOSITORY_ID }}\",
+                 categoryId: \"${{ env.CATEGORY_ID }}\",
+                 body: \"${{ env.DISCUSSION_BODY }}\",
+                 title: \"${{ env.DISCUSSION_TITLE }}\"
+                 }
+             )
+             {
+               discussion {id}
+             }
+           }"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-- Added a workflow for generating Hackday Github Discussions thread
-  ([#801](https://github.com/nsidc/earthaccess/issues/801))
-  ([@Sherwin-14](https://github.com/Sherwin-14),
-   [@mfisher87](https://github.com/mfisher87))
-
 ## [v0.12.0] - 2024-11-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+- Added a workflow for generating Hackday Github Discussions thread
+  ([#801](https://github.com/nsidc/earthaccess/issues/801))
+  ([@Sherwin-14](https://github.com/Sherwin-14),
+   [@mfisher87](https://github.com/mfisher87))
+
 ## [v0.12.0] - 2024-11-13
 
 ### Changed


### PR DESCRIPTION
I have replaced the CATEGORY_ID and REPOSITORY_ID, though, it remains untested. (It would be funny if Github allowed me to open a discussions thread in another repository :laughing:)




<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--914.org.readthedocs.build/en/914/

<!-- readthedocs-preview earthaccess end -->