### PR TITLE
Fixed issue when `FileDistributionInformation` doesn't exist in a summary() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 - Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
 - Resolved an error in virtual dataset tutorial notebook ([#1044](https://github.com/nsidc/earthaccess/issues/1044))([danielfromearth](https://github.com/danielfromearth))
+- Issue when `FileDistributionInformation` did not exist for a collection
+  ([#971](https://github.com/nsidc/earthaccess/pull/971))
+  ([@mike-gangl](https://github.com/mike-gangl/))
 
 ## [v0.14.0] - 2025-02-11
 

--- a/earthaccess/results.py
+++ b/earthaccess/results.py
@@ -124,11 +124,15 @@ class DataCollection(CustomDict):
             The collection data type, i.e. HDF5, CSV etc., if available.
         """
         if "ArchiveAndDistributionInformation" in self["umm"]:
-            return str(
-                self["umm"]["ArchiveAndDistributionInformation"][
-                    "FileDistributionInformation"
-                ]
-            )
+            if (
+                "FileDistributionInformation"
+                in self["umm"]["ArchiveAndDistributionInformation"]
+            ):
+                return str(
+                    self["umm"]["ArchiveAndDistributionInformation"][
+                        "FileDistributionInformation"
+                    ]
+                )
         return ""
 
     def version(self) -> str:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -158,6 +158,12 @@ def test_dataset_search_returns_valid_results(kwargs):
     assert isinstance(results[0], dict)
 
 
+def test_dataset_search_summary_missing_file_dist_info():
+    results = earthaccess.search_datasets(short_name="AIRS_CPR_IND", daac="GES_DISC")
+    collection_with_no_FileDistributionInformation = results[0]
+    assert collection_with_no_FileDistributionInformation.summary()["file-type"] == ""
+
+
 @pytest.mark.parametrize("kwargs", granules_valid_params)
 def test_granules_search_returns_valid_results(kwargs):
     results = earthaccess.search_data(count=10, **kwargs)


### PR DESCRIPTION
Closes #970 

Simple fix to check for `FileDistributionInformation` existence before using it in the response. Id it does not exist, we return the empty string.

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [x] Add unit tests for any new features.
- [x] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--971.org.readthedocs.build/en/971/

<!-- readthedocs-preview earthaccess end -->