### PR TITLE
Run pytest with `--color=yes` on GitHub Actions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -120,6 +120,7 @@ jobs:
             --cov=earthaccess \
             --cov-report=term-missing \
             --capture=no \
+            --color=yes \
             --tb=native \
             --log-cli-level=INFO
 

--- a/.github/workflows/test-mindeps.yml
+++ b/.github/workflows/test-mindeps.yml
@@ -37,7 +37,7 @@ jobs:
         run: uv sync --resolution lowest-direct --extra test
 
       - name: Test
-        run: uv run pytest tests/unit --verbose --cov=earthaccess --cov=tests --cov-report=term-missing --capture=no --tb=native --log-cli-level=INFO
+        run: uv run pytest tests/unit --verbose --cov=earthaccess --cov=tests --cov-report=term-missing --capture=no --color=yes --tb=native --log-cli-level=INFO
 
       - name: Upload coverage
         # Don't upload coverage when using the `act` tool to run the workflow locally

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv run mypy
 
       - name: Test
-        run: uv run pytest tests/unit --verbose --cov=earthaccess --cov-report=term-missing --capture=no --tb=native --log-cli-level=INFO
+        run: uv run pytest tests/unit --verbose --cov=earthaccess --cov-report=term-missing --capture=no --color=yes --tb=native --log-cli-level=INFO
 
       - name: Upload coverage
         # Don't upload coverage when using the `act` tool to run the workflow locally


### PR DESCRIPTION
GitHub Actions doesn't show colour outputs for pytest by default (https://github.com/pytest-dev/pytest/issues/7443), but it can be enabled by setting a `--color=yes` flag.

| Before (black & white :panda_face:) | After (color :rainbow:) |
|--|--|
|![image](https://github.com/user-attachments/assets/c6a81191-1347-4c26-9e62-efb6c25cc484) | ![image](https://github.com/user-attachments/assets/d7c98961-65b2-45cb-87ee-b2a7a53377a5) |

Enables color output for pytest on:
- .github/workflows/integration-test.yml
- .github/workflows/test-mindeps.yml
- .github/workflows/test.yml

<!--
Replace this text, including the symbols above and below it, with descriptive text about
the change you are proposing. Please include a reference to any issues addressed or
resolved in that text, for example "resolves #1".
-->

<!--
IMPORTANT: As a contributor, we would like as much help as you can offer, but we only
expect you to complete the steps in the "PR draft checklist" below. Maintainers are
willing and ready to help pick it up from there!

Please start by opening this Pull Request as a "draft". You can do this by
clicking the arrow on the right side of the green "Create pull request" button. While
your pull request is in "draft" state, maintainers will assume the PR isn't ready for
their attention unless they are specifically summoned using GitHub's @ system.

Follow the draft checklist below to move the PR out of draft state. If you accidentally
created the PR as a non-draft, don't worry, you can still change it to a draft using the
"Convert to draft" button on  the right side panel under the "Reviewers" section.
-->

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [ ] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [ ] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--982.org.readthedocs.build/en/982/

<!-- readthedocs-preview earthaccess end -->