### PR TITLE
Update bug and triage label names in bug Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,8 +3,8 @@ description: >
   A bug is an issue that differs from documentation or has unexpected behavior.
 title: "[BUG] {{ title }}"
 labels:
-  - Bug
-  - Needs Triage
+  - "type: bug"
+  - "needs: triage"
 body:
   - type: checkboxes
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Updated bug and triage label names in bug Issue template.
   ([#998](https://github.com/nsidc/earthaccess/pull/998))
   ([@asteiker](https://github.com/asteiker))
+
 ## [v0.14.0] - 2025-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
 
+### Changed
+- Updated bug and triage label names in bug Issue template.
+  ([#998](https://github.com/nsidc/earthaccess/pull/998)
+
 ## [v0.14.0] - 2025-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 - Updated bug and triage label names in bug Issue template.
-  ([#998](https://github.com/nsidc/earthaccess/pull/998)
-  ([@asteiker](https://github.com/asteiker)
+  ([#998](https://github.com/nsidc/earthaccess/pull/998))
+  ([@asteiker](https://github.com/asteiker))
 ## [v0.14.0] - 2025-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Changed
 - Updated bug and triage label names in bug Issue template.
   ([#998](https://github.com/nsidc/earthaccess/pull/998)
-
+  ([@asteiker](https://github.com/asteiker)
 ## [v0.14.0] - 2025-02-11
 
 ### Added


### PR DESCRIPTION
Resolves #984 . This is a small update to the bug template to include a new triage label, and fixing the existing bug label to align with our label updates per #760. @mfisher87 also suggested updating other issue templates while I'm in here, but we only have this bug template along with a config.yml, which only points to Discussions or a blank issue. Lmk if I'm missing something here! 

<!--
IMPORTANT: As a contributor, we would like as much help as you can offer, but we only
expect you to complete the steps in the "PR draft checklist" below. Maintainers are
willing and ready to help pick it up from there!

Please start by opening this Pull Request as a "draft". You can do this by
clicking the arrow on the right side of the green "Create pull request" button. While
your pull request is in "draft" state, maintainers will assume the PR isn't ready for
their attention unless they are specifically summoned using GitHub's @ system.

Follow the draft checklist below to move the PR out of draft state. If you accidentally
created the PR as a non-draft, don't worry, you can still change it to a draft using the
"Convert to draft" button on  the right side panel under the "Reviewers" section.
-->

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Update the documentation and/or the `README.md` with details of changes to the
      earthaccess interface, if any. Consider new environment variables, function names,
      decorators, etc.

Click the "Ready for review" button at the bottom of the "Conversation" tab in GitHub
once these requirements are fulfilled. Don't worry if you see any test failures in
GitHub at this point!

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- [ ] Add unit tests for any new features.
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--998.org.readthedocs.build/en/998/

<!-- readthedocs-preview earthaccess end -->