### PR TITLE
Write PR comment when int. tests fail on insufficient perms

### DIFF
--- a/.github/workflows/integration-test-review.yml
+++ b/.github/workflows/integration-test-review.yml
@@ -19,11 +19,52 @@ jobs:
           require: write
           username: ${{ github.triggering_actor }}
 
-      - name: Add PR comment when user does not have write permission
+      # The remaining steps are run only if the triggering actor (user) does NOT have
+      # write permission for the repo, in which case, the purpose of the remaining
+      # steps is to add a comment to the PR indicating that the actor (user) does
+      # NOT have permissions to run integration tests, and thus a maintainer must
+      # make sure the PR is "safe", and if so, re-run the "failed" integration tests
+      # (because maintainers DO have the necessary write permission).
+
+      - name: Download PR number artifact
         # The name of the output require-result is a bit confusing, but when its value
         # is 'false', it means that the triggering actor does NOT have the required
         # permission.
-        if: steps.permission.outputs.require-result == 'false'
+        if: ${{ !env.ACT && steps.permission.outputs.require-result == 'false' }}
+        uses: actions/github-script@v7
+        with:
+          # Download the PR artifact that was uploaded in integration-test.yml
+          script: |
+            const { owner, repo }  = context.repo;
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner, repo, run_id: context.payload.workflow_run.id,
+            });
+            const prNumberArtifact = artifacts.data.artifacts.filter(
+              (artifact) => artifact.name == "pr_number"
+            )[0];
+            const download = await github.rest.actions.downloadArtifact({
+               owner, repo, artifact_id: prNumberArtifact.id, archive_format: 'zip',
+            });
+
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+
+            if (!fs.existsSync(temp)) {
+              fs.mkdirSync(temp);
+            }
+
+            fs.writeFileSync(path.join(temp, 'pr_number.zip'), Buffer.from(download.data));
+
+      - name: Unzip downloaded PR number artifact
+        if: ${{ !env.ACT && steps.permission.outputs.require-result == 'false' }}
+        run: unzip pr_number.zip -d "${{ runner.temp }}/artifacts"
+
+      - name: Add PR comment
+        # The name of the output require-result is a bit confusing, but when its value
+        # is 'false', it means that the triggering actor does NOT have the required
+        # permission.
+        if: ${{ !env.ACT && steps.permission.outputs.require-result == 'false' }}
 
         # If the triggering actor does not have write permission, then we want to add
         # a PR comment indicating a security review is required because we know that
@@ -31,17 +72,23 @@ jobs:
         # actually "aborted" without running any tests).
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { html_url } = await github.rest.issues.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            const fs = require('fs');
+            const path = require('path');
+            const temp = '${{ runner.temp }}/artifacts';
+            const { owner, repo } = context.repo;
+
+            // Read the PR number from the downloaded and unzipped artifact.
+            const issue_number = Number(fs.readFileSync(path.join(temp, 'pr_number')));
+
+            // Get the URL of the PR so we can add a link in the PR comment.
+            const { html_url } = await github.rest.issues.get({ owner, repo, issue_number });
 
             github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
+              owner,
+              repo,
+              issue_number,
               body: "User [${{ github.triggering_actor }}](${{ github.event.workflow_run.head_repository.owner.html_url }})"
                 + " does not have permission to run integration tests. A maintainer must perform a security review of the"
                 + ` [code changes in this pull request](${html_url}/files) and re-run the`

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -58,7 +58,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        include:
+          - python-version: 3.11
+            # We must save the PR number only once, and this also prevents
+            # "duplicate artifact" errors caused when attempting to save the same
+            # artifact for every python version we're running with.  More specifically,
+            # save-pr-number must be set to 'true' for 1 (and only 1) matrix combo
+            # (it doesn't matter which combo).
+            save-pr-number: true
+          - python-version: 3.12
+            save-pr-number: false
+          - python-version: 3.13
+            save-pr-number: false
       fail-fast: false
 
     steps:
@@ -67,6 +78,7 @@ jobs:
       # insufficient permissions), which is handled in integration-test-review.yml.
       # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#using-data-from-the-triggering-workflow
       - name: Save PR number
+        if: matrix.save-pr-number
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
@@ -74,6 +86,7 @@ jobs:
           echo $PR_NUMBER > ./pr/pr_number
 
       - uses: actions/upload-artifact@v4
+        if: matrix.save-pr-number
         with:
           path: pr/
           name: pr_number

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,6 +62,22 @@ jobs:
       fail-fast: false
 
     steps:
+      # The first 2 steps will save the PR number to a file and upload the file as an
+      # artifact, which we can then download if the workflow run fails (due to
+      # insufficient permissions), which is handled in integration-test-review.yml.
+      # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: pr/
+          name: pr_number
+
       - name: Fetch user permission
         if: github.event_name == 'pull_request_target'
         id: permission


### PR DESCRIPTION
Yet another attempt to get auto-commenting on PRs to work.

Fixes #1005

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1006.org.readthedocs.build/en/1006/

<!-- readthedocs-preview earthaccess end -->