### PR TITLE
Added experience reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/experience-report.yml
+++ b/.github/ISSUE_TEMPLATE/experience-report.yml
@@ -1,0 +1,13 @@
+name: '🗺️ Experience report'
+description: 'Help us level up Earthaccess by sharing your unfiltered experiences, wins, and struggles'
+labels:
+  - 'experience report'
+body:
+  - type: 'textarea'
+    attributes:
+      label: 'Description'
+      description: |
+        Provide detailed feedback on your Earthaccess experience, including successes, challenges, and suggestions for improvement. 
+        Your insights will inform our development roadmap and community efforts.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/experience-report.yml
+++ b/.github/ISSUE_TEMPLATE/experience-report.yml
@@ -1,13 +1,13 @@
 name: '🗺️ Experience report'
 description: 'Help us level up Earthaccess by sharing your unfiltered experiences, wins, and struggles'
 labels:
-  - 'experience report'
+  - 'type: experience report'
 body:
   - type: 'textarea'
     attributes:
       label: 'Description'
       description: |
-        Provide detailed feedback on your Earthaccess experience, including successes, challenges, and suggestions for improvement. 
+        Provide detailed feedback on your Earthaccess experience, including successes, challenges, and suggestions for improvement.
         Your insights will inform our development roadmap and community efforts.
     validations:
       required: true

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -101,3 +101,6 @@ files = earthaccess.download(results, "./local_folder")
 
 Data can also be opened in-memory with `earthaccess.open()`. See [our API
 docs](user-reference/api/api.md) for more.
+
+
+We value your feedback! We want to hear all about your experience using earthaccess. Even if you're not noticing any issues or bugs, we want to know... what annoys you? What feels great? We'd love if you would share an experience [report](https://github.com/nsidc/earthaccess/issues) with us!

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -103,4 +103,4 @@ Data can also be opened in-memory with `earthaccess.open()`. See [our API
 docs](user-reference/api/api.md) for more.
 
 
-We value your feedback! We want to hear all about your experience using earthaccess. Even if you're not noticing any issues or bugs, we want to know... what annoys you? What feels great? We'd love if you would share an experience [report](https://github.com/nsidc/earthaccess/issues) with us!
+We value your feedback! We want to hear all about your experience using earthaccess. Even if you're not noticing any issues or bugs, we want to know... what annoys you? What feels great? We'd love if you would share an experience [report](https://github.com/nsidc/earthaccess/issues/new/choose) with us!


### PR DESCRIPTION
I have added a template for experience reports as well as a call for them in the quickstart guide, as discussed in the [issue](https://github.com/nsidc/earthaccess/issues/575). 

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1008.org.readthedocs.build/en/1008/

<!-- readthedocs-preview earthaccess end -->