### PR TITLE
Add an exception `DownloadFailure` for handling failure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,13 +29,17 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   ([#612](https://github.com/nsidc/earthaccess/issues/612))
   ([@Sherwin-14](https://github.com/Sherwin-14))
 
-### Fixed
-- Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
-
-### Changed
 - Updated bug and triage label names in bug Issue template.
   ([#998](https://github.com/nsidc/earthaccess/pull/998))
   ([@asteiker](https://github.com/asteiker))
+
+- `download` now raises `DownloadFailure` exception on failure.
+  ([#612](https://github.com/nsidc/earthaccess/issues/612))
+  ([@Sherwin-14](https://github.com/Sherwin-14))
+
+### Fixed
+- Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
+
 
 ## [v0.14.0] - 2025-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ### Fixed
 - Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
 
-
 ## [v0.14.0] - 2025-02-11
 
 ### Added

--- a/earthaccess/exceptions.py
+++ b/earthaccess/exceptions.py
@@ -26,6 +26,7 @@ class LoginAttemptFailure(Exception):
 
     pass
 
+
 class DownloadFailure(Exception):
     """The download attempt failed.
 

--- a/earthaccess/exceptions.py
+++ b/earthaccess/exceptions.py
@@ -25,3 +25,17 @@ class LoginAttemptFailure(Exception):
     """
 
     pass
+
+class DownloadFailure(Exception):
+    """The login attempt failed.
+
+    This should be raised when a login attempt fails, for example, because
+    the user's credentials were rejected.
+
+    DO NOT raise this exception when a login strategy can't be attempted. For
+    example, this exception would not be thrown when "environment" was selected
+    but the envvars are not populated; a `LoginStrategyUnavailable` should be
+    thrown instead.
+    """
+
+    pass

--- a/earthaccess/exceptions.py
+++ b/earthaccess/exceptions.py
@@ -27,15 +27,10 @@ class LoginAttemptFailure(Exception):
     pass
 
 class DownloadFailure(Exception):
-    """The login attempt failed.
+    """The download attempt failed.
 
-    This should be raised when a login attempt fails, for example, because
-    the user's credentials were rejected.
-
-    DO NOT raise this exception when a login strategy can't be attempted. For
-    example, this exception would not be thrown when "environment" was selected
-    but the envvars are not populated; a `LoginStrategyUnavailable` should be
-    thrown instead.
+    This should be raised when a download attempt fails, for example, because
+    the file could not be retrieved or the download process was interrupted.
     """
 
     pass

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -19,6 +19,7 @@ from typing_extensions import deprecated
 import earthaccess
 
 from .auth import Auth, SessionWithHeaderRedirection
+from .exceptions import DownloadFailure
 from .daac import DAAC_TEST_URLS, find_provider
 from .results import DataGranule
 from .search import DataCollections
@@ -706,8 +707,9 @@ class Store(object):
                         for chunk in r.iter_content(chunk_size=1024 * 1024):
                             f.write(chunk)
             except Exception:
-                logger.exception(f"Error while downloading the file {local_filename}")
-                raise Exception
+                msg = f"Error while downloading the file {local_filename}"
+                logger.error(msg)
+                raise DownloadFailure(msg)
         else:
             logger.info(f"File {local_filename} already downloaded")
         return str(path)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -19,8 +19,8 @@ from typing_extensions import deprecated
 import earthaccess
 
 from .auth import Auth, SessionWithHeaderRedirection
-from .exceptions import DownloadFailure
 from .daac import DAAC_TEST_URLS, find_provider
+from .exceptions import DownloadFailure
 from .results import DataGranule
 from .search import DataCollections
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -655,7 +655,7 @@ class Store(object):
                         logger.info(f"Downloaded: {file_name}")
                         downloaded_files.append(file_name)
                     except Exception as e:
-                        msg = f"Failed to download:{file_name}:{e}"
+                        msg = f"Failed to download {file!r} to {file_name!r}: {e}"
                         logger.error(msg)
                         raise DownloadFailure(msg)
             return downloaded_files

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -597,7 +597,7 @@ class Store(object):
                         logger.info(f"Downloaded: {file_name}")
                         downloaded_files.append(file_name)
                     except Exception as e:
-                        msg = f"Failed to download:{file_name}:{e}"
+                        msg = f"Failed to download {file!r} to {file_name!r}: {e}"
                         logger.error(msg)
                         raise DownloadFailure(msg)
             return downloaded_files

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -706,7 +706,7 @@ class Store(object):
                         # https://docs.python-requests.org/en/latest/user/quickstart/#raw-response-content
                         for chunk in r.iter_content(chunk_size=1024 * 1024):
                             f.write(chunk)
-            except Exception:
+            except Exception as e:
                 msg = f"Error while downloading the file {local_filename}"
                 logger.error(msg)
                 raise DownloadFailure(msg)

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -592,9 +592,14 @@ class Store(object):
             for file in data_links:
                 file_name = local_path / Path(file).name
                 if not file_name.exists():
-                    s3_fs.get(file, str(local_path))
-                    logger.info(f"Downloaded: {file_name}")
-                    downloaded_files.append(file_name)
+                    try:
+                        s3_fs.get(file, str(local_path))
+                        logger.info(f"Downloaded: {file_name}")
+                        downloaded_files.append(file_name)
+                    except Exception as e:
+                        msg = f"Failed to download:{file_name}:{e}"
+                        logger.error(msg)
+                        raise DownloadFailure(msg)
             return downloaded_files
 
         else:
@@ -624,7 +629,7 @@ class Store(object):
                 granule.data_links(access=access, in_region=self.in_region)
                 for granule in granules
             )
-        )   
+        )
         total_size = round(sum(granule.size() for granule in granules) / 1024, 2)
         logger.info(
             f" Getting {len(granules)} granules, approx download size: {total_size} GB"
@@ -645,9 +650,14 @@ class Store(object):
             for file in data_links:
                 file_name = local_path / Path(file).name
                 if not file_name.exists():
-                    s3_fs.get(file, str(local_path))
-                    logger.info(f"Downloaded: {file_name}")
-                    downloaded_files.append(file_name)
+                    try:
+                        s3_fs.get(file, str(local_path))
+                        logger.info(f"Downloaded: {file_name}")
+                        downloaded_files.append(file_name)
+                    except Exception as e:
+                        msg = f"Failed to download:{file_name}:{e}"
+                        logger.error(msg)
+                        raise DownloadFailure(msg)
             return downloaded_files
         else:
             # if the data are cloud-based, but we are not in AWS,
@@ -707,7 +717,7 @@ class Store(object):
                         for chunk in r.iter_content(chunk_size=1024 * 1024):
                             f.write(chunk)
             except Exception as e:
-                msg = f"Error while downloading the file {local_filename}"
+                msg = f"Failed to download {url!r} to {path!r}: {e}"
                 logger.error(msg)
                 raise DownloadFailure(msg)
         else:

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -624,7 +624,7 @@ class Store(object):
                 granule.data_links(access=access, in_region=self.in_region)
                 for granule in granules
             )
-        )
+        )   
         total_size = round(sum(granule.size() for granule in granules) / 1024, 2)
         logger.info(
             f" Getting {len(granules)} granules, approx download size: {total_size} GB"


### PR DESCRIPTION
I have added the logic for handling download failure as discussed [here](https://github.com/nsidc/earthaccess/issues/996).  Also I observed that we have same block for Changed twice in CHANGELOG, is this done on purpose?

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1012.org.readthedocs.build/en/1012/

<!-- readthedocs-preview earthaccess end -->