### PR TITLE
Fix path to pr_number.zip artifact

### DIFF
--- a/.github/workflows/integration-test-review.yml
+++ b/.github/workflows/integration-test-review.yml
@@ -48,7 +48,7 @@ jobs:
 
             const fs = require('fs');
             const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
+            const temp = path.join('${{ runner.temp }}', 'artifacts');
 
             if (!fs.existsSync(temp)) {
               fs.mkdirSync(temp);
@@ -58,7 +58,7 @@ jobs:
 
       - name: Unzip downloaded PR number artifact
         if: ${{ !env.ACT && steps.permission.outputs.require-result == 'false' }}
-        run: unzip pr_number.zip -d "${{ runner.temp }}/artifacts"
+        run: unzip "${{ runner.temp }}/artifacts/pr_number.zip" -d "${{ runner.temp }}/artifacts"
 
       - name: Add PR comment
         # The name of the output require-result is a bit confusing, but when its value
@@ -76,7 +76,7 @@ jobs:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const temp = '${{ runner.temp }}/artifacts';
+            const temp = path.join('${{ runner.temp }}', 'artifacts');
             const { owner, repo } = context.repo;
 
             // Read the PR number from the downloaded and unzipped artifact.


### PR DESCRIPTION
Hopefully this is the last fix to get PR comments to work. The workflow was attempting to unzip the pr_number.zip artifact at the wrong path, so was failing the workflow to add the PR comment.

These changes _should_ allow the unzip to work now, which should then allow the PR number to be read from the unzipped artifact, which should then allow a comment to be added to the PR.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1013.org.readthedocs.build/en/1013/

<!-- readthedocs-preview earthaccess end -->