### PR TITLE
Fix link to PR files in PR auto-comment

### DIFF
--- a/.github/workflows/integration-test-review.yml
+++ b/.github/workflows/integration-test-review.yml
@@ -57,6 +57,9 @@ jobs:
             fs.writeFileSync(path.join(temp, 'pr_number.zip'), Buffer.from(download.data));
 
       - name: Unzip downloaded PR number artifact
+        # The name of the output require-result is a bit confusing, but when its value
+        # is 'false', it means that the triggering actor does NOT have the required
+        # permission.
         if: ${{ !env.ACT && steps.permission.outputs.require-result == 'false' }}
         run: unzip "${{ runner.temp }}/artifacts/pr_number.zip" -d "${{ runner.temp }}/artifacts"
 
@@ -80,15 +83,15 @@ jobs:
             const { owner, repo } = context.repo;
 
             // Read the PR number from the downloaded and unzipped artifact.
-            const issue_number = Number(fs.readFileSync(path.join(temp, 'pr_number')));
+            const pr_number = Number(fs.readFileSync(path.join(temp, 'pr_number')));
 
             // Get the URL of the PR so we can add a link in the PR comment.
-            const { html_url } = await github.rest.issues.get({ owner, repo, issue_number });
+            const { html_url } = await github.rest.pulls.get({ owner, repo, pr_number });
 
             github.rest.issues.createComment({
               owner,
               repo,
-              issue_number,
+              pr_number,
               body: "User [${{ github.triggering_actor }}](${{ github.event.workflow_run.head_repository.owner.html_url }})"
                 + " does not have permission to run integration tests. A maintainer must perform a security review of the"
                 + ` [code changes in this pull request](${html_url}/files) and re-run the`


### PR DESCRIPTION
The auto-comment on PRs is now working! See #1013 for the fix, and #1012 for correctly added comments.

However within the auto-generated comment, the link on the text "code changes in this pull request" is broken, so it doesn't properly link to the files (diff) view of the PR.

This PR attempts to fix the broken link in the generated comment.

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1014.org.readthedocs.build/en/1014/

<!-- readthedocs-preview earthaccess end -->