### PR TITLE
Add documentation of the Decision Committee process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 *   @betolink @jhkennedy @jrbourbeau @mfisher87 @chuckwondo
 
 # Decision committee members
-docs/governance/decisions/*   @betolink @jhkennedy @mfisher87 @chuckwondo @Sherwin-14 @asteiker @itcarroll
+docs/governance/decisions/*   @betolink @jhkennedy @mfisher87 @chuckwondo @asteiker @itcarroll

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# How the CODEOWNERS file works:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Earthaccess default set of maintainers who will be automatically requested for review
+*   @betolink @jhkennedy @jrbourbeau @mfisher87 @chuckwondo
+
+# Decision committee members
+docs/governance/decisions/*   @betolink @jhkennedy @mfisher87 @chuckwondo @Sherwin-14 @asteiker @itcarroll

--- a/docs/governance/governance-process.md
+++ b/docs/governance/governance-process.md
@@ -1,0 +1,38 @@
+# Earthaccess Governance
+
+Earthaccess is an open source project devoted to providing easy access to NASA's Earth data. Earthaccess, importantly, is developed _for_ and _by_ the community.  
+
+As with any project, from time to time, decisions will need to be made about direction, features, engineering choices. Eathaccess values reaching a community consensus on those decisions and including as many community perspectives as possible.
+
+Examples of when the decision committee may need to be invoked:
+* Issues that relate to **significant changes** to earthaccess framework, or way we develop earthaccess
+* When there is a **disagreement** on a path forward
+
+In order to reach consensus, Earthacess has a developed an _asynchronous_ decision processes, that in brief looks like:
+
+1. GitHub issues can be labeled `needs: decision` by anyone to kick off the decision committee process
+2. A PR will be automatically created with a blank decision record document and a member of the decision committee will be assigned at random to shepherd the decision through the processes
+3. The assignee will create a _first_ draft of the decision record document, summarizing the relevant issues, discussion, and pull requests, and then mark it as ready for review
+4. The decision committee will use PR review mechanics to discuss the decision and suggest changes or edit the decision record to reflect the decision and discussion
+   - Decision committee members endorse a decision as written by approving the PR
+   - Decision committee members can reject a decision _as written_ by requesting changes in the PR
+   - Decision committee member can express neutral discussion points by leaving PR comments 
+5. Once N decision committee members endorse a decision (approve the PR), the decision is considered "decided" and the PR should be merged to record the decisions
+6. The PR assignee should update any relevant GitHub issues, discussion, and pull requests with the decision and a link back to the decision record PR
+
+## Decision Committee Members
+
+Decision committee members are listed in the [CODEOWNERS](../../.github/CODEOWNERS). Importantly, this is the _default_ members of the committee. The committee can change based on the issue itself by requesting additional reviewers. 
+
+Want to be part of decisions? Open a PR adding yourself to the CODEOWNERS file!
+
+
+## Process in detail
+
+### Kicking off the decision committee process
+
+### Decision records
+
+### The review process
+
+### When a decision is made


### PR DESCRIPTION
In the May 13th hackday, we discussed the decision committee a bit and started to develop what the actual process could/should look like. 

We decided to try and use standard GitHub PR workflows to facilitate a decision, which I've outlined here, and use #1011 to work through the processes and try it out.

I'm leaving this as draft while we work through the process in #1011 as I expect we will update it as we go, but this will at least provide a frame of reference. 

TODOs:
- [ ] Write a GitHub action that creates a draft decision record PR that is triggered on labeling an issue or PR that it https://github.com/nsidc/earthaccess/labels/needs%3A%20decision
   - [ ] :question: Possibly also 'on: workflow_dispatch` to create one manually
   - [ ] :question: use a ruleset or step in the PR to auto-assign the PR (see: [enabling auto assignment](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment) for one way to do this) 
- [ ] Ensure CODEOWNERS is accurate and everyone listed is on board with how they are listed in the doc
- [ ] :question: Add this and any decisions to our website


--- 

> [!NOTE]
> This would be a lot easier to manage using teams, which would also be a lot easier to manage in an org, so we might want to make a decision for #929 as well