### PR TITLE
Update function docstrings with GES_DISC to match daac.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   ([#612](https://github.com/nsidc/earthaccess/issues/612))
   ([@Sherwin-14](https://github.com/Sherwin-14))
 
+- `GESDISC` should be `GES_DISC` in docstrings.
+  ([#1037](https://github.com/nsidc/earthaccess/issues/1037))
+  ([@abarciauskas-bgse](https://github.com/abarciauskas-bgse))
+
 ### Fixed
 - Corrected Harmony typo in notebooks/Demo.ipynb([#995](https://github.com/nsidc/earthaccess/issues/995))([stelios-c](https://github.com/stelios-c))
 

--- a/earthaccess/search.py
+++ b/earthaccess/search.py
@@ -360,7 +360,7 @@ class DataCollections(CollectionQuery):
         """An alias for the `daac` method.
 
         Parameters:
-            data_center_name: DAAC shortname, e.g. NSIDC, PODAAC, GESDISC
+            data_center_name: DAAC shortname, e.g. NSIDC, PODAAC, GES_DISC
 
         Returns:
             self
@@ -372,7 +372,7 @@ class DataCollections(CollectionQuery):
         for the DAAC.
 
         Parameters:
-            daac_short_name: a DAAC shortname, e.g. NSIDC, PODAAC, GESDISC
+            daac_short_name: a DAAC shortname, e.g. NSIDC, PODAAC, GES_DISC
 
         Returns:
             self
@@ -556,7 +556,7 @@ class DataGranules(GranuleQuery):
         """An alias for the `daac` method.
 
         Parameters:
-            data_center_name (String): DAAC shortname, e.g. NSIDC, PODAAC, GESDISC
+            data_center_name (String): DAAC shortname, e.g. NSIDC, PODAAC, GES_DISC
 
         Returns:
             self
@@ -568,7 +568,7 @@ class DataGranules(GranuleQuery):
         the DAAC.
 
         Parameters:
-            daac_short_name: a DAAC shortname, e.g. NSIDC, PODAAC, GESDISC
+            daac_short_name: a DAAC shortname, e.g. NSIDC, PODAAC, GES_DISC
 
         Returns:
             self


### PR DESCRIPTION
I was tripped up by functions' docstrings suggesting the string to use as the "daac" argument for GESDISC should be "GESDISC" but it is actually set to "GES_DISC" in daac.py. This PR updates those docstrings.

<details><summary>Pull Request (PR) draft checklist - click to expand</summary>

- [x] Please review our
      [contributing documentation](https://earthaccess.readthedocs.io/en/latest/contributing/)
      before getting started.
- [x] Populate a descriptive title. For example, instead of "Updated README.md", use a
      title such as "Add testing details to the contributor section of the README".
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)
- [x] Populate the body of the pull request with:
    - A clear description of the change you are proposing.
    - Links to any issues resolved by this PR with text in the PR description, for
      example `closes #1`. See
      [GitHub docs - Linking a pull request to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
- [x] Update `CHANGELOG.md` with details about your change in a section titled
      `## Unreleased`. If such a section does not exist, please create one. Follow
      [Common Changelog](https://common-changelog.org/) for your additions.
      Example PRs: [#763](https://github.com/nsidc/earthaccess/pull/763)

</details>

<details><summary>Pull Request (PR) merge checklist - click to expand</summary>

Please do your best to complete these requirements! If you need help with any of these
requirements, you can ping the `@nsidc/earthaccess-support` team in a comment and we
will help you out!

- ~Add unit tests for any new features.~
- [ ] Apply formatting and linting autofixes. You can add a GitHub comment in this Pull
      Request containing "pre-commit.ci autofix" to automate this.
- [ ] Ensure all automated PR checks (seen at the bottom of the "conversation" tab) pass.
- [ ] Get at least one approving review.

</details>


<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1037.org.readthedocs.build/en/1037/

<!-- readthedocs-preview earthaccess end -->