### PR TITLE
Show progress bar in interactive sessions (Jupyter, REPL) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
-- By default, _disable_ progress bars during downloading.
+- Allow users to disable progress bar if needed, show for interactive sessions.
   ([#612](https://github.com/nsidc/earthaccess/issues/612))
+  ([#1065](https://github.com/nsidc/earthaccess/pull/1065))
   ([@Sherwin-14](https://github.com/Sherwin-14))
 - Updated bug and triage label names in bug Issue template.
   ([#998](https://github.com/nsidc/earthaccess/pull/998))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
-- Allow users to disable progress bar if needed, show for interactive sessions.
+- Add `show_progress` argument to `earthaccess.download()` to let the user control display of progress bars. Defaults to true for interactive sessions, otherwise false.
   ([#612](https://github.com/nsidc/earthaccess/issues/612))
   ([#1065](https://github.com/nsidc/earthaccess/pull/1065))
   ([@Sherwin-14](https://github.com/Sherwin-14))

--- a/docs/howto/authenticate.md
+++ b/docs/howto/authenticate.md
@@ -57,7 +57,7 @@ credentials in two locations:
    used throughout documentation primarily for convenience.  The only
    requirement is that the *contents* of the file adhere to the
    [`.netrc` file format](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html).
-   
+
 2. `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables (or, optionally, `EARTHDATA_TOKEN`
    to use an existing Earthdata Login token)
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -301,8 +301,7 @@ def download(
             of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
-        show_progress: if False, earthaccess will not show the progress bar for downloads. True if
-            the session is interactive.
+        show_progress: whether to display a progress bar. Defaults to `True` for interactive sessions, otherwise `False`.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -252,7 +252,7 @@ def download(
             of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
-        hide_progress: if True, will not show the progress bar for downloads. True if 
+        hide_progress: if True, will not show the progress bar for downloads. True if
             the session is non-interactive.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
@@ -273,7 +273,12 @@ def download(
 
     try:
         return earthaccess.__store__.get(
-            granules, local_path, provider, threads, hide_progress=hide_progress, pqdm_kwargs=pqdm_kwargs
+            granules,
+            local_path,
+            provider,
+            threads,
+            hide_progress=hide_progress,
+            pqdm_kwargs=pqdm_kwargs,
         )
     except AttributeError as err:
         logger.error(

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -283,7 +283,7 @@ def download(
     provider: Optional[str] = None,
     threads: int = 8,
     *,
-    hide_progress: bool = False,
+    show_progress: Optional[bool] = None,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[Path]:
     """Retrieves data granules from a remote storage system. Provide the optional `local_path` argument to prevent repeated downloads.
@@ -301,8 +301,8 @@ def download(
             of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
-        hide_progress: if True, will not show the progress bar for downloads. True if
-            the session is non-interactive.
+        show_progress: if False, earthaccess will not show the progress bar for downloads. True if
+            the session is interactive.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.
@@ -326,7 +326,7 @@ def download(
             local_path,
             provider,
             threads,
-            hide_progress=hide_progress,
+            show_progress=show_progress,
             pqdm_kwargs=pqdm_kwargs,
         )
     except AttributeError as err:
@@ -341,7 +341,7 @@ def open(
     granules: Union[List[str], List[DataGranule]],
     provider: Optional[str] = None,
     *,
-    hide_progress: bool = False,
+    show_progress: Optional[bool] = None,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of file-like objects that can be used to access files
@@ -351,8 +351,8 @@ def open(
         granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
             If a list of URLs is passed, we need to specify the data provider.
         provider: e.g. POCLOUD, NSIDC_CPRD, etc.
-        hide_progress: if True, will not show the progress bar for downloads. True if
-            the session is non interactive.
+        show_progress: if False, earthaccess will not show the progress bar for downloads. Defaults to True if
+            the session is interactive.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.
@@ -363,7 +363,7 @@ def open(
     return earthaccess.__store__.open(
         granules=granules,
         provider=_normalize_location(provider),
-        hide_progress=hide_progress,
+        show_progress=show_progress,
         pqdm_kwargs=pqdm_kwargs,
     )
 

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -301,7 +301,8 @@ def download(
             of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
-        show_progress: whether to display a progress bar. Defaults to `True` for interactive sessions, otherwise `False`.
+        show_progress: whether or not to display a progress bar. If not specified, defaults to `True` for interactive sessions
+            (i.e., in a notebook or a python REPL session), otherwise `False`.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.
@@ -350,8 +351,8 @@ def open(
         granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
             If a list of URLs is passed, we need to specify the data provider.
         provider: e.g. POCLOUD, NSIDC_CPRD, etc.
-        show_progress: if False, earthaccess will not show the progress bar for downloads. Defaults to True if
-            the session is interactive.
+        show_progress: whether or not to display a progress bar. If not specified, defaults to `True` for interactive sessions
+            (i.e., in a notebook or a python REPL session), otherwise `False`.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.

--- a/earthaccess/api.py
+++ b/earthaccess/api.py
@@ -234,6 +234,7 @@ def download(
     provider: Optional[str] = None,
     threads: int = 8,
     *,
+    hide_progress: bool = False,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[Path]:
     """Retrieves data granules from a remote storage system. Provide the optional `local_path` argument to prevent repeated downloads.
@@ -251,6 +252,8 @@ def download(
             of a UUID4 value.
         provider: if we download a list of URLs, we need to specify the provider.
         threads: parallel number of threads to use to download the files, adjust as necessary, default = 8
+        hide_progress: if True, will not show the progress bar for downloads. True if 
+            the session is non-interactive.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.
@@ -270,7 +273,7 @@ def download(
 
     try:
         return earthaccess.__store__.get(
-            granules, local_path, provider, threads, pqdm_kwargs=pqdm_kwargs
+            granules, local_path, provider, threads, hide_progress=hide_progress, pqdm_kwargs=pqdm_kwargs
         )
     except AttributeError as err:
         logger.error(
@@ -284,6 +287,7 @@ def open(
     granules: Union[List[str], List[DataGranule]],
     provider: Optional[str] = None,
     *,
+    hide_progress: bool = False,
     pqdm_kwargs: Optional[Mapping[str, Any]] = None,
 ) -> List[AbstractFileSystem]:
     """Returns a list of file-like objects that can be used to access files
@@ -293,6 +297,8 @@ def open(
         granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
             If a list of URLs is passed, we need to specify the data provider.
         provider: e.g. POCLOUD, NSIDC_CPRD, etc.
+        hide_progress: if True, will not show the progress bar for downloads. True if
+            the session is non interactive.
         pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
             See pqdm documentation for available options. Default is to use immediate exception behavior
             and the number of jobs specified by the `threads` parameter.
@@ -303,6 +309,7 @@ def open(
     return earthaccess.__store__.open(
         granules=granules,
         provider=_normalize_location(provider),
+        hide_progress=hide_progress,
         pqdm_kwargs=pqdm_kwargs,
     )
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -562,7 +562,7 @@ class Store(object):
 
         pqdm_kwargs = {
             "n_jobs": threads,
-            "disable": not show_progress,  # True if show_progrss is False
+            "disable": not show_progress,
             **(pqdm_kwargs or {}),
         }
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -378,8 +378,8 @@ class Store(object):
         Returns:
             A list of "file pointers" to remote (i.e. s3 or https) files.
         """
-        if not _is_interactive() and show_progress is None:
-            show_progress = False
+    if show_progress is None:
+        show_progress = _is_interactive()
 
         pqdm_kwargs = {
             "exception_behaviour": "immediate",

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -361,7 +361,7 @@ class Store(object):
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
         *,
-        hide_progress: Optional[bool] = None,
+        show_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[fsspec.spec.AbstractBufferedFile]:
         """Returns a list of file-like objects that can be used to access files
@@ -371,20 +371,20 @@ class Store(object):
             granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
                 If a list of URLs is passed, we need to specify the data provider.
             provider: e.g. POCLOUD, NSIDC_CPRD, etc.
-            hide_progress: If True, progress bars will be hidden. Default is False.
+            show_progress: If False, progress bars will be hidden. Default is False.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior.
 
         Returns:
             A list of "file pointers" to remote (i.e. s3 or https) files.
         """
-        if not _is_interactive() and hide_progress is None:
-            hide_progress = True
+        if not _is_interactive() and show_progress is None:
+            show_progress = False
 
         pqdm_kwargs = {
             "exception_behaviour": "immediate",
             "n_jobs": 8,
-            "disable": hide_progress,
+            "disable": not show_progress,
             **(pqdm_kwargs or {}),
         }
         if len(granules):
@@ -519,7 +519,7 @@ class Store(object):
         provider: Optional[str] = None,
         threads: int = 8,
         *,
-        hide_progress: Optional[bool] = None,
+        show_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[Path]:
         """Retrieves data granules from a remote storage system.
@@ -541,7 +541,7 @@ class Store(object):
             provider: a valid cloud provider, each DAAC has a provider code for their cloud distributions
             threads: Parallel number of threads to use to download the files;
                 adjust as necessary, default = 8.
-            hide_progress: If True, progress bars will be hidden. Default is False.
+            show_progress: If False, progress bars will be hidden. Default is True.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior
                 and the number of jobs specified by the `threads` parameter.
@@ -557,12 +557,12 @@ class Store(object):
             uuid = uuid4().hex[:6]
             local_path = Path.cwd() / "data" / f"{today}-{uuid}"
 
-        if not _is_interactive() and hide_progress is None:
-            hide_progress = True
+        if not _is_interactive() and show_progress is None:
+            show_progress = False
 
         pqdm_kwargs = {
             "n_jobs": threads,
-            "disable": hide_progress,
+            "disable": not show_progress,  # True if show_progrss is False
             **(pqdm_kwargs or {}),
         }
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -378,8 +378,8 @@ class Store(object):
         Returns:
             A list of "file pointers" to remote (i.e. s3 or https) files.
         """
-    if show_progress is None:
-        show_progress = _is_interactive()
+        if show_progress is None:
+            show_progress = _is_interactive()
 
         pqdm_kwargs = {
             "exception_behaviour": "immediate",

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -60,6 +60,7 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
     def __repr__(self) -> str:
         return repr(self.f)
 
+
 def _is_interactive() -> bool:
     """Detect if earthaccess is being used in an interactive session.
     Interactive sessions include Jupyter Notebooks, IPython REPL, and default Python REPL.

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -43,10 +43,7 @@ def _is_interactive() -> bool:
     import sys
 
     # Python REPL
-    if hasattr(sys, "ps1"):
-        return True
-
-    return False
+    return hasattr(sys, "ps1")
 
 
 class EarthAccessFile(fsspec.spec.AbstractBufferedFile):

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -60,6 +60,27 @@ class EarthAccessFile(fsspec.spec.AbstractBufferedFile):
     def __repr__(self) -> str:
         return repr(self.f)
 
+def _is_interactive() -> bool:
+    """Detect if earthaccess is being used in an interactive session.
+    Interactive sessions include Jupyter Notebooks, IPython REPL, and default Python REPL.
+    """
+    try:
+        from IPython import get_ipython  # type: ignore
+
+        # IPython Notebook or REPL:
+        if get_ipython() is not None:
+            return True
+    except ImportError:
+        pass
+
+    import sys
+
+    # Python REPL
+    if hasattr(sys, "ps1"):
+        return True
+
+    return False
+
 
 def _open_files(
     url_mapping: Mapping[str, Union[DataGranule, None]],
@@ -70,13 +91,6 @@ def _open_files(
     def multi_thread_open(data: tuple[str, Optional[DataGranule]]) -> EarthAccessFile:
         url, granule = data
         return EarthAccessFile(fs.open(url), granule)  # type: ignore
-
-    pqdm_kwargs = {
-        "exception_behaviour": "immediate",
-        "n_jobs": 8,
-        "disable": True,
-        **(pqdm_kwargs or {}),
-    }
 
     return pqdm(url_mapping.items(), multi_thread_open, **pqdm_kwargs)
 
@@ -346,6 +360,7 @@ class Store(object):
         granules: Union[List[str], List[DataGranule]],
         provider: Optional[str] = None,
         *,
+        hide_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[fsspec.spec.AbstractBufferedFile]:
         """Returns a list of file-like objects that can be used to access files
@@ -355,12 +370,22 @@ class Store(object):
             granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
                 If a list of URLs is passed, we need to specify the data provider.
             provider: e.g. POCLOUD, NSIDC_CPRD, etc.
+            hide_progress: If True, progress bars will be hidden. Default is False.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior.
 
         Returns:
             A list of "file pointers" to remote (i.e. s3 or https) files.
         """
+        if not _is_interactive() and hide_progress is None:
+            hide_progress = True
+
+        pqdm_kwargs = {
+            "exception_behaviour": "immediate",
+            "n_jobs": 8,
+            "disable": hide_progress,
+            **(pqdm_kwargs or {}),
+        }
         if len(granules):
             return self._open(granules, provider, pqdm_kwargs=pqdm_kwargs)
         return []
@@ -436,6 +461,7 @@ class Store(object):
         granules: List[str],
         provider: Optional[str] = None,
         *,
+        hide_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[Any]:
         fileset: List = []
@@ -463,6 +489,7 @@ class Store(object):
                         fileset = _open_files(
                             url_mapping,
                             fs=s3_fs,
+                            hide_progress=hide_progress,
                             pqdm_kwargs=pqdm_kwargs,
                         )
                     except Exception as e:
@@ -493,6 +520,7 @@ class Store(object):
         provider: Optional[str] = None,
         threads: int = 8,
         *,
+        hide_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[Path]:
         """Retrieves data granules from a remote storage system.
@@ -514,6 +542,7 @@ class Store(object):
             provider: a valid cloud provider, each DAAC has a provider code for their cloud distributions
             threads: Parallel number of threads to use to download the files;
                 adjust as necessary, default = 8.
+            hide_progress: If True, progress bars will be hidden. Default is False.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior
                 and the number of jobs specified by the `threads` parameter.
@@ -529,9 +558,12 @@ class Store(object):
             uuid = uuid4().hex[:6]
             local_path = Path.cwd() / "data" / f"{today}-{uuid}"
 
+        if not _is_interactive() and hide_progress is None:
+            hide_progress = True
+
         pqdm_kwargs = {
             "n_jobs": threads,
-            "disable": True,
+            "disable": hide_progress,
             **(pqdm_kwargs or {}),
         }
 

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -461,7 +461,6 @@ class Store(object):
         granules: List[str],
         provider: Optional[str] = None,
         *,
-        hide_progress: Optional[bool] = None,
         pqdm_kwargs: Optional[Mapping[str, Any]] = None,
     ) -> List[Any]:
         fileset: List = []
@@ -489,7 +488,6 @@ class Store(object):
                         fileset = _open_files(
                             url_mapping,
                             fs=s3_fs,
-                            hide_progress=hide_progress,
                             pqdm_kwargs=pqdm_kwargs,
                         )
                     except Exception as e:

--- a/earthaccess/store.py
+++ b/earthaccess/store.py
@@ -368,7 +368,8 @@ class Store(object):
             granules: a list of granule instances **or** list of URLs, e.g. `s3://some-granule`.
                 If a list of URLs is passed, we need to specify the data provider.
             provider: e.g. POCLOUD, NSIDC_CPRD, etc.
-            show_progress: If False, progress bars will be hidden. Default is False.
+            show_progress: whether or not to display a progress bar. If not specified, defaults to `True` for interactive sessions
+                (i.e., in a notebook or a python REPL session), otherwise `False`.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior.
 
@@ -538,7 +539,8 @@ class Store(object):
             provider: a valid cloud provider, each DAAC has a provider code for their cloud distributions
             threads: Parallel number of threads to use to download the files;
                 adjust as necessary, default = 8.
-            show_progress: If False, progress bars will be hidden. Default is True.
+            show_progress: whether or not to display a progress bar. If not specified, defaults to `True` for interactive sessions
+                (i.e., in a notebook or a python REPL session), otherwise `False`.
             pqdm_kwargs: Additional keyword arguments to pass to pqdm, a parallel processing library.
                 See pqdm documentation for available options. Default is to use immediate exception behavior
                 and the number of jobs specified by the `threads` parameter.


### PR DESCRIPTION
This is a minor patch to restore the progress bar when we open and download files, the default is to show it if we are in a notebook and there is a new parameter to mute it with `hide_progress` in both download() and open(). 

<!-- readthedocs-preview earthaccess start -->
----
📚 Documentation preview 📚: https://earthaccess--1065.org.readthedocs.build/en/1065/

<!-- readthedocs-preview earthaccess end -->